### PR TITLE
Made instructions less redundant as suggested by @sergiobenrocha2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,46 @@ ifneq ($(GIT_VERSION)," unknown")
 	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif
 
-ifeq ($(platform), unix)
-   TARGET := $(TARGET_NAME)_libretro.so
-   fpic := -fPIC
-   SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
+ifneq (,$(findstring unix,$(platform)))
+    AR = ${CC_PREFIX}ar
+    CC = ${CC_PREFIX}gcc
+
+    TARGET := $(TARGET_NAME)_libretro.so
+    fpic := -fPIC
+    SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
+
+
+    # Raspberry Pi
+    ifneq (,$(findstring rpi,$(platform)))
+        CFLAGS += -fomit-frame-pointer -ffast-math -DARM -marm -mfloat-abi=hard
+
+        # Pi (original)
+        ifneq (,$(findstring rpi1,$(platform)))
+            CFLAGS = -mcpu=cortex-a6j
+        # Pi2
+        else ifneq (,$(findstring rpi2,$(platform)))
+            CFLAGS = -mcpu=cortex-a7
+        # Pi3
+        else ifneq (,$(findstring rpi3,$(platform)))
+            CFLAGS = -mcpu=cortex-a53
+        endif
+
+	# ODROIDs
+    else ifneq (,$(findstring odroid,$(platform)))
+        CFLAGS += -fomit-frame-pointer -ffast-math -DARM -marm -mfloat-abi=hard
+
+        # ODROID-C1
+        ifneq (,$(findstring odroidc,$(platform)))
+            CFLAGS += -mtune=cortex-a5
+        # ODROID-XU3 & ODROID-XU4
+        else ifneq (,$(findstring odroidxu,$(platform)))
+            CFLAGS += -march=armv7ve -mtune=cortex-a15.cortex-a7
+        # ODROID-U2, -U3, -X & -X2
+        else
+            CFLAGS += -mtune=cortex-a9
+        endif
+    endif
+
 else ifeq ($(platform), osx)
    TARGET := $(TARGET_NAME)_libretro.dylib
    fpic := -fPIC
@@ -133,47 +169,6 @@ else ifeq ($(platform), ctr)
 else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
    STATIC_LINKING = 1
-
-# Raspberry Pi
-else ifneq (,$(findstring rpi,$(platform)))
-	AR = ${CC_PREFIX}ar
-	CC = ${CC_PREFIX}gcc
-
-	EXT    ?= so
-	TARGET := $(TARGET_NAME)_libretro.$(EXT)
-	SHARED := -shared -Wl,--version-script=link.T
-	fpic = -fPIC
-	ifneq (,$(findstring rpi2,$(platform)))
-		CFLAGS = -mcpu=cortex-a7 -mfloat-abi=hard
-	endif
-
-# ODROIDs
-else ifneq (,$(findstring odroid,$(platform)))
-	AR = ${CC_PREFIX}ar
-	CC = ${CC_PREFIX}gcc
-
-	EXT    ?= so
-	TARGET := $(TARGET_NAME)_libretro.$(EXT)
-ifeq ($(BOARD),1)
-	BOARD := $(shell cat /proc/cpuinfo | grep -i odroid | awk '{print $$3}')
-endif
-	SHARED := -shared -Wl,--version-script=link.T
-	fpic = -fPIC
-	CFLAGS += -marm -mfloat-abi=hard
-	ifneq (,$(findstring ODROIDC,$(BOARD)))
-		# ODROID-C1
-		CFLAGS += -mtune=cortex-a5
-	else ifneq (,$(findstring ODROID-XU3,$(BOARD)))
-		# ODROID-XU3 & -XU3 Lite
-		ifeq "$(shell expr `gcc -dumpversion` \>= 4.9)" "1"
-			CFLAGS += -march=armv7ve -mtune=cortex-a15.cortex-a7
-		else
-			CFLAGS += -mtune=cortex-a9
-		endif
-	else
-		# ODROID-U2, -U3, -X & -X2
-		CFLAGS += -mtune=cortex-a9
-	endif
 
 else
    TARGET := $(TARGET_NAME)_libretro.dll


### PR DESCRIPTION
Support for RPi* and Odroid* goes like this:
* unix-rpi1
* unix-rpi2
* unix-rpi3
* unix-odroidc (ODroid-C1)
* unix-odroidxu (ODroid-XU3 and ODroid-XU4)
* unix-odroid

Example:
```
platform="unix-odroidxu" make
```