### PR TITLE
add menu options for hacks

### DIFF
--- a/libfreedo/freedocore.h
+++ b/libfreedo/freedocore.h
@@ -110,12 +110,12 @@ typedef void* (*_ext_Interface)(int, void*);
 #define FDP_SET_ANVIL           20
 
 #define FIX_BIT_TIMING_1        (0x00000001)
-#define FIX_BIT_TIMING_2        (0x00000002)
+//#define FIX_BIT_TIMING_2        (0x00000002)
 #define FIX_BIT_TIMING_3        (0x00000004)
-#define FIX_BIT_TIMING_4        (0x00000008)
+//#define FIX_BIT_TIMING_4        (0x00000008)
 #define FIX_BIT_TIMING_5        (0x00000010)
 #define FIX_BIT_TIMING_6        (0x00000020)
-#define FIX_BIT_TIMING_7        (0x00000040)
+//#define FIX_BIT_TIMING_7        (0x00000040)
 #define FIX_BIT_GRAPHICS_STEP_Y (0x00080000) // Preserve Y coordinate rather than X between CELs.
 
 #define BIOS_ANVIL (0x40)


### PR DESCRIPTION
Added timing and graphics hacks for certain games as found in 3DO 1.3.2.4. The reason for the hacks don't appear to be documented anywhere (including the 4DO commits) so while it'd be nice to fix the underlying issue that may not be possible with reverse engineering.

A future enhancement may be adding auto detection.

The Super Street Fighter 2 hack was actually never implemented. The flag would be set but never checked. I've attempted to replicate the hack from a previous release but without much luck. Will investigate further but it appears to only affect the timing of the thunder & lightning during the intro.