### PR TITLE
Implement disk control/m3u support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -415,7 +415,7 @@ $(TARGET): $(OBJECTS)
 ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 else
-	$(LD) $(LINKOUT)$@ $^ $(LDFLAGS)
+	$(LD) $(LINKOUT)$@ $^ $(LDFLAGS) $(CFLAGS)
 endif
 
 %.o: %.c

--- a/Makefile.common
+++ b/Makefile.common
@@ -15,6 +15,7 @@ endif
 SOURCES_C := \
 	$(CORE_DIR)/libretro.c \
 	$(CORE_DIR)/cuefile.c \
+	$(CORE_DIR)/disk_control.c \
 	$(CORE_DIR)/nvram.c \
 	$(CORE_DIR)/retro_callbacks.c \
         $(CORE_DIR)/retro_cdimage.c \

--- a/cuefile.c
+++ b/cuefile.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include <libretro.h>
+#include <file/file_path.h>
 
 #include "cuefile.h"
 #include "retro_callbacks.h"
@@ -17,6 +18,18 @@ static FILE *cue_get_file_for_image(const char *path)
    char cue_path[8192];
    char *exts[]   = {".cue", ".CUE"};
    char *last_dot = NULL;
+   const char *ext;
+       FILE *cue_file = NULL;
+
+   ext = path_get_extension(path);
+   if(ext == NULL)
+       return NULL;
+
+   if(!strncasecmp(ext, "cd", 2)) {
+       cue_file = fopen(path, "r");
+       if (cue_file)
+           return cue_file;
+   }
 
    strncpy(cue_path_base, path, STRING_MAX);
 

--- a/cuefile.c
+++ b/cuefile.c
@@ -19,16 +19,16 @@ static FILE *cue_get_file_for_image(const char *path)
    char *exts[]   = {".cue", ".CUE"};
    char *last_dot = NULL;
    const char *ext;
-       FILE *cue_file = NULL;
 
    ext = path_get_extension(path);
    if(ext == NULL)
        return NULL;
 
    if(!strncasecmp(ext, "cd", 2)) {
-       cue_file = fopen(path, "r");
-       if (cue_file)
-           return cue_file;
+     FILE *cue_file = NULL;
+     cue_file = fopen(path, "r");
+     if (cue_file)
+       return cue_file;
    }
 
    strncpy(cue_path_base, path, STRING_MAX);

--- a/disk_control.c
+++ b/disk_control.c
@@ -1,0 +1,212 @@
+#include "disk_control.h"
+#include "retro_callbacks.h"
+#include "retro_cdimage.h"
+
+#include <string.h>
+#include <libretro.h>
+#include <file/file_path.h>
+#include <streams/file_stream.h>
+
+
+
+static bool disk_set_eject_state(bool ejected)
+{
+	disk_control_state.ejected = ejected;
+	return true;
+}
+
+static bool disk_get_eject_state(void)
+{
+	return disk_control_state.ejected;
+}
+
+static unsigned int disk_get_image_index(void)
+{
+	return disk_control_state.current_index;
+}
+
+static bool disk_set_image_index(unsigned int index)
+{
+  int rv;
+  if ((rv = disk_control_swap(&disk_control_state, index)) != 0) {
+    retro_log_printf_cb(RETRO_LOG_ERROR, "unable to switch to disk: #%u\n", index);
+    return false;
+  }
+  retro_reset();
+  return true;
+}
+
+static unsigned int disk_get_num_images(void)
+{
+	return disk_control_state.count;
+}
+
+static bool disk_replace_image_index(unsigned index,
+	const struct retro_game_info *info)
+{
+  char *old_fname;
+  bool rv = true;
+  if (index >= disk_control_length(&disk_control_state)) {
+    return false;
+  }
+
+  cdimage_t *cd = disk_control_get_disk(&disk_control_state, index);
+  old_fname = cd->filename;
+  cd->filename = NULL;
+
+  if (info != NULL) {
+    cd->filename = strdup(info->path);
+    if (index == disk_control_state.current_index)
+      rv = disk_set_image_index(index);
+  }
+
+  if (old_fname != NULL)
+    free(old_fname);
+
+  return rv;
+}
+
+static bool disk_add_image_index(void)
+{
+  if (disk_control_state.count >= 8)
+    return false;
+
+  disk_control_state.count++;
+  return true;
+}
+
+int
+disk_control_open_m3u_file(const char *path_)
+{
+  int rv;
+  char line[PATH_MAX];
+  char name[PATH_MAX];
+  FILE *f = fopen(path_, "r");
+  if (!f)
+      return false;
+
+  char *base_dir = strdup(path_);
+  path_basedir(base_dir);
+
+  disk_control_t *dc = disk_control_get();
+  while (fgets(line, sizeof(line), f) && dc->count < disk_control_length(dc)) {
+    if (line[0] == '#')
+      continue;
+    char *carrige_return = strchr(line, '\r');
+    if (carrige_return)
+      *carrige_return = '\0';
+    char *newline = strchr(line, '\n');
+    if (newline)
+      *newline = '\0';
+    if (line[0] != '\0') {
+      snprintf(name, sizeof(name), "%s%c%s", base_dir, SLASH, line);
+      cdimage_t *cd = malloc(sizeof(cdimage_t));
+      cd->filename = strdup(name);
+      disk_control_add_disk(dc, cd);
+    }
+  }
+  if ((rv = retro_cdimage_open_cue(disk_control_get_disk(dc, 0)->filename, disk_control_get_disk(dc, 0))) != 0) {
+    retro_log_printf_cb(RETRO_LOG_ERROR, "error %d opening cdimage: %d\n", rv, 0);
+    return -1;
+  };
+
+  fclose(f);
+  return (dc->count != 0);
+}
+
+void
+disk_control_destroy(disk_control_t *dc)
+{
+  int rv;
+  for (int i = 0; i < DISK_MAX; i++) {
+    cdimage_t *cd = disk_control_get_disk(dc, i);
+    if (cd != NULL) {
+      if ((rv = retro_cdimage_close(cd)) > 0) {
+        retro_log_printf_cb(RETRO_LOG_ERROR, "error %d closing cdimage: %d\n", rv, i);
+        continue;
+      }
+      if (cd->filename != NULL) {
+        free(cd->filename);
+      }
+      free(cd);
+    }
+  }
+}
+
+static
+int
+disk_control_switch_image(disk_control_t *dc, int index)
+{
+  int rv;
+  cdimage_t *new_disk = disk_control_get_disk(dc, index);
+  if (new_disk->filename == NULL) {
+    retro_log_printf_cb(RETRO_LOG_ERROR, "missing disk #%u\n", index);
+
+    // RetroArch specifies "no disk" with index == count,
+    // so don't fail here..
+    dc->current_index = index;
+    return -1;
+  }
+
+  retro_log_printf_cb(RETRO_LOG_INFO, "switching to disk %u: \"%s\"\n", index,
+    new_disk->filename);
+
+  if ((rv = retro_cdimage_close(disk_control_get_current_disk(dc))) > 0) {
+    retro_log_printf_cb(RETRO_LOG_ERROR, "error %d closing cdimage: %d\n", rv, index);
+    return -1;
+  }
+
+  if ((rv = retro_cdimage_open_cue(new_disk->filename, new_disk)) > 0) {
+    retro_log_printf_cb(RETRO_LOG_ERROR, "error %d opening cdimage: %d\n", rv, index);
+    return -1;
+  }
+  dc->current_index = index;
+  return 0;
+}
+
+int
+disk_control_open_file(const char *path_)
+{
+  const char *ext;
+  int rv;
+
+  ext = path_get_extension(path_);
+  if(ext == NULL)
+    return -1;
+
+  if(!strcasecmp(ext,"m3u"))
+    return disk_control_open_m3u_file(path_);
+
+  disk_control_t *dc = &disk_control_state;
+  cdimage_t cd;
+  rv = retro_cdimage_open(path_, &cd);
+  if (rv == -1)
+    return -1;
+  disk_control_add_disk(dc, &cd);
+  return 0;
+}
+
+uint32_t disk_image_get_size(void)
+{
+  return retro_cdimage_get_number_of_logical_blocks(disk_control_get_current_disk(disk_control_get()));
+}
+
+void disk_image_set_sector(const uint32_t sector_)
+{
+  disk_control_state.current_sector = sector_;
+}
+
+void disk_image_read_sector(void *buf_)
+{
+  retro_cdimage_read(disk_control_get_current_disk(disk_control_get()), disk_control_state.current_sector, buf_, 2048);
+}
+
+struct retro_disk_control_callback disk_control_cb = {
+	.set_eject_state = disk_set_eject_state,
+	.get_eject_state = disk_get_eject_state,
+	.get_image_index = disk_get_image_index,
+	.set_image_index = disk_set_image_index,
+	.get_num_images = disk_get_num_images,
+	.replace_image_index = disk_replace_image_index,
+	.add_image_index = disk_add_image_index,
+};

--- a/disk_control.h
+++ b/disk_control.h
@@ -1,0 +1,59 @@
+#ifndef LIBRETRO_4DO_DISK_CONTROL_H_INCLUDED
+#define LIBRETRO_4DO_DISK_CONTROL_H_INCLUDED
+
+#include "retro_cdimage.h"
+
+#ifdef _WIN32
+#define SLASH '\\'
+#else
+#define SLASH '/'
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX  4096
+#endif
+
+#ifndef DISK_MAX
+#define DISK_MAX  8
+#endif
+
+struct disk_control_s
+{
+  bool ejected;
+  int current_sector;
+  unsigned int current_index;
+  unsigned int count;
+  cdimage_t *disks[DISK_MAX];
+};
+
+typedef struct disk_control_s disk_control_t;
+
+int disk_control_open_file(const char *path_);
+
+static disk_control_t disk_control_state = {
+  .ejected = false,
+  .current_sector = 0,
+  .current_index = 0,
+  .count = 0,
+};
+
+#define disk_control_add_disk(obj, item) ((obj)->disks[(obj)->count++] = item)
+#define disk_control_cleanup() (disk_control_destroy(disk_control_get()))
+#define disk_control_get() (&(disk_control_state))
+#define disk_control_get_current_disk(obj) (disk_control_get_disk(obj, (obj)->current_index))
+#define disk_control_get_disk(obj, index) ((obj)->disks[index])
+#define disk_control_length(obj) (sizeof((obj)->disks) / sizeof((obj)->disks[0]))
+#define disk_control_swap(obj, index) (disk_control_switch_image(obj, index))
+
+void disk_control_destroy(disk_control_t *dc);
+static int disk_control_switch_image(disk_control_t *dc, int image_index);
+
+// libfreedo cdrom callbacks
+uint32_t disk_image_get_size(void);
+void disk_image_set_sector(const uint32_t sector_);
+void disk_image_read_sector(void *buf_);
+
+// libretro disk control callbacks
+struct retro_disk_control_callback disk_control_cb;
+
+#endif

--- a/libfreedo/endianness.h
+++ b/libfreedo/endianness.h
@@ -70,7 +70,7 @@
 
 #define is_little_endian() (0)
 #define swap32_if_little_endian(X) (X)
-#define swap32_array_if_little_endian(X,Y) 
+#define swap32_array_if_little_endian(X,Y)
 
 #else
 
@@ -90,8 +90,5 @@ swap32_array_if_little_endian(uint32_t *array_,
 }
 
 #endif /* IS_BIG_ENDIAN */
-
-#undef SWAP32
-#undef IS_BIG_ENDIAN
 
 #endif /* LIBFREEDO_ENDIANNESS_H_INCLUDED */

--- a/libfreedo/endianness.h
+++ b/libfreedo/endianness.h
@@ -3,6 +3,8 @@
 
 #include "inline.h"
 
+#include <stdint.h>
+
 #if defined(__linux__)
 #include <endian.h>
 #endif

--- a/libfreedo/freedo_arm.c
+++ b/libfreedo/freedo_arm.c
@@ -1801,7 +1801,7 @@ freedo_mem_write8(uint32_t addr_,
                   uint8_t  val_)
 {
   CPU.ram[addr_] = val_;
-  if(addr_ < 0x200000 || !HIRESMODE)
+  if(!HIRESMODE || (addr_ < 0x200000))
     return;
   CPU.ram[addr_ + 1*1024*1024] = val_;
   CPU.ram[addr_ + 2*1024*1024] = val_;
@@ -1813,7 +1813,7 @@ freedo_mem_write16(uint32_t addr_,
                    uint16_t val_)
 {
   *((uint16_t*)&CPU.ram[addr_]) = val_;
-  if(addr_ < 0x200000 || !HIRESMODE)
+  if(!HIRESMODE || (addr_ < 0x200000))
     return;
   *((uint16_t*)&CPU.ram[addr_ + 1*1024*1024]) = val_;
   *((uint16_t*)&CPU.ram[addr_ + 2*1024*1024]) = val_;
@@ -1825,7 +1825,7 @@ freedo_mem_write32(uint32_t addr_,
                    uint32_t val_)
 {
   *((uint32_t*)&CPU.ram[addr_]) = val_;
-  if(addr_ < 0x200000 || !HIRESMODE)
+  if(!HIRESMODE || (addr_ < 0x200000))
     return;
   *((uint32_t*)&CPU.ram[addr_ + 1*1024*1024]) = val_;
   *((uint32_t*)&CPU.ram[addr_ + 2*1024*1024]) = val_;

--- a/libfreedo/freedo_madam.c
+++ b/libfreedo/freedo_madam.c
@@ -384,13 +384,38 @@ struct madam_s
 
 typedef struct madam_s madam_t;
 
+#define ME_MODE_HARDWARE 0
+#define ME_MODE_SOFTWARE 1
+#define MADAM_ID_RED_HARDWARE   0x01000000
+#define MADAM_ID_GREEN_HARDWARE 0x01020000
+#define MADAM_ID_GREEN_SOFTWARE 0x01020001
+
 static madam_t MADAM;
-static int     KPRINT = 0;
+static int KPRINT  = 0;
+static int ME_MODE = ME_MODE_HARDWARE;
 
 void
-freedo_madam_kprint_set(const int v_)
+freedo_madam_kprint_enable(void)
 {
-  KPRINT = v_;
+  KPRINT = 1;
+}
+
+void
+freedo_madam_kprint_disable(void)
+{
+  KPRINT = 0;
+}
+
+void
+freedo_madam_me_mode_hardware(void)
+{
+  ME_MODE = ME_MODE_HARDWARE;
+}
+
+void
+freedo_madam_me_mode_software(void)
+{
+  ME_MODE = ME_MODE_SOFTWARE;
 }
 
 uint32_t
@@ -1206,6 +1231,8 @@ freedo_madam_init(uint8_t *mem_)
   int32_t j;
   int32_t n;
 
+  freedo_madam_reset();
+
   ADD       = 0;
   USECEL    = 1;
   CELCYCLES = 0;
@@ -1215,20 +1242,13 @@ freedo_madam_init(uint8_t *mem_)
 
   MADAM.FSM = FSM_IDLE;
 
-  for(i = 0; i < MADAM_REGISTER_COUNT; i++)
-    MADAM.mregs[i] = 0;
+  MADAM.mregs[0] = ((ME_MODE == ME_MODE_HARDWARE) ?
+                    MADAM_ID_GREEN_HARDWARE :
+                    MADAM_ID_GREEN_SOFTWARE);
 
   /* DRAM dux init */
   MADAM.mregs[4]   = 0x29;
   MADAM.mregs[574] = 0xFFFFFFFC;
-
-#if 1
-  MADAM.mregs[0] = 0x01020000;  /* for Green MADAM */
-  // MADAM.mregs[0] = 0x01000000;  /* for Red MADAM? */
-  // MADAM.mregs[0] = 0x02022000;  /* for Green matrix engine autodetect */
-#else
-  MADAM.mregs[0] = 0x01020001;  /* for ARM soft emu of matrix engine */
-#endif
 
   for(i = 0; i < 32; i++)
     for(j = 0; j < 8; j++)

--- a/libfreedo/freedo_madam.c
+++ b/libfreedo/freedo_madam.c
@@ -37,6 +37,7 @@
 #include "freedo_vdlp.h"
 #include "hack_flags.h"
 #include "inline.h"
+#include "endianness.h"
 
 #include <math.h>
 #include <stdint.h>
@@ -1189,28 +1190,29 @@ static
 void
 DMAPBus(void)
 {
-  uint32_t  i;
   uint32_t *pbus_buf;
   int32_t   pbus_size;
 
   if((int32_t)MADAM.mregs[0x574] < 0)
     return;
 
+  freedo_pbus_pad();
+
   MADAM.mregs[0x574] -= 4;
   MADAM.mregs[0x570] += 4;
   MADAM.mregs[0x578] += 4;
 
-  i = 0;
-  pbus_buf = freedo_pbus_buf();
+  pbus_buf  = freedo_pbus_buf();
   pbus_size = freedo_pbus_size();
   while(((int32_t)MADAM.mregs[0x574] > 0) && (pbus_size > 0))
     {
-      freedo_io_write(MADAM.mregs[0x570],pbus_buf[i]);
-      MADAM.mregs[0x574] -= 4;
+      freedo_io_write(MADAM.mregs[0x570],
+                      swap32_if_little_endian(*pbus_buf));
+      pbus_buf++;
       pbus_size          -= 4;
+      MADAM.mregs[0x574] -= 4;
       MADAM.mregs[0x570] += 4;
       MADAM.mregs[0x578] += 4;
-      i++;
     }
 
   while((int32_t)MADAM.mregs[0x574] > 0)

--- a/libfreedo/freedo_madam.h
+++ b/libfreedo/freedo_madam.h
@@ -45,8 +45,7 @@ void      freedo_madam_reset(void);
 uint32_t  freedo_madam_fsm_get(void);
 void      freedo_madam_fsm_set(uint32_t val_);
 
-uint32_t  freedo_madam_cel_get_cycles(void);
-uint32_t  freedo_madam_cel_handle(void);
+void      freedo_madam_cel_handle(void);
 
 uint32_t *freedo_madam_registers(void);
 

--- a/libfreedo/freedo_madam.h
+++ b/libfreedo/freedo_madam.h
@@ -53,7 +53,10 @@ uint32_t *freedo_madam_registers(void);
 void      freedo_madam_poke(uint32_t addr_, uint32_t val_);
 uint32_t  freedo_madam_peek(uint32_t addr_);
 
-void      freedo_madam_kprint_set(const int v_);
+void      freedo_madam_kprint_enable(void);
+void      freedo_madam_kprint_disable(void);
+void      freedo_madam_me_mode_software(void);
+void      freedo_madam_me_mode_hardware(void);
 
 uint32_t  freedo_madam_state_size(void);
 void      freedo_madam_state_save(void *buf_);

--- a/libfreedo/freedo_pbus.c
+++ b/libfreedo/freedo_pbus.c
@@ -4,36 +4,50 @@
 
 #define PBUS_BUF_SIZE 256
 
-#define PBUS_FLIGHTSTICK_ID       0x01
-#define PBUS_JOYPAD_ID            0x80
-#define PBUS_MOUSE_ID             0x49
-#define PBUS_LIGHTGUN_ID          0x4D
-#define PBUS_ORBATAK_TRACKBALL_ID PBUS_MOUSE_ID
-#define PBUS_ORBATAK_BUTTONS_ID   0xC0
+#define PBUS_FLIGHTSTICK_ID_0       0x01
+#define PBUS_FLIGHTSTICK_ID_1       0x7B
+#define PBUS_JOYPAD_ID              0x80
+#define PBUS_MOUSE_ID               0x49
+#define PBUS_LIGHTGUN_ID            0x4D
+#define PBUS_ORBATAK_TRACKBALL_ID   PBUS_MOUSE_ID
+#define PBUS_ORBATAK_BUTTONS_ID     0xC0
 
-#define PBUS_JOYPAD_SHIFT_LT       0x02
-#define PBUS_JOYPAD_SHIFT_RT       0x03
-#define PBUS_JOYPAD_SHIFT_X        0x04
-#define PBUS_JOYPAD_SHIFT_P        0x05
-#define PBUS_JOYPAD_SHIFT_C        0x06
-#define PBUS_JOYPAD_SHIFT_B        0x07
-#define PBUS_JOYPAD_SHIFT_A        0x00
-#define PBUS_JOYPAD_SHIFT_L        0x01
-#define PBUS_JOYPAD_SHIFT_R        0x02
-#define PBUS_JOYPAD_SHIFT_U        0x03
-#define PBUS_JOYPAD_SHIFT_D        0x04
+#define PBUS_JOYPAD_SHIFT_LT        0x02
+#define PBUS_JOYPAD_SHIFT_RT        0x03
+#define PBUS_JOYPAD_SHIFT_X         0x04
+#define PBUS_JOYPAD_SHIFT_P         0x05
+#define PBUS_JOYPAD_SHIFT_C         0x06
+#define PBUS_JOYPAD_SHIFT_B         0x07
+#define PBUS_JOYPAD_SHIFT_A         0x00
+#define PBUS_JOYPAD_SHIFT_L         0x01
+#define PBUS_JOYPAD_SHIFT_R         0x02
+#define PBUS_JOYPAD_SHIFT_U         0x03
+#define PBUS_JOYPAD_SHIFT_D         0x04
 
-#define PBUS_MOUSE_SHIFT_LEFT   7
-#define PBUS_MOUSE_SHIFT_MIDDLE 6
-#define PBUS_MOUSE_SHIFT_RIGHT  5
-#define PBUS_MOUSE_SHIFT_SHIFT  4
+#define PBUS_FLIGHTSTICK_SHIFT_FIRE 0x07
+#define PBUS_FLIGHTSTICK_SHIFT_A    0x06
+#define PBUS_FLIGHTSTICK_SHIFT_B    0x05
+#define PBUS_FLIGHTSTICK_SHIFT_C    0x04
+#define PBUS_FLIGHTSTICK_SHIFT_U    0x03
+#define PBUS_FLIGHTSTICK_SHIFT_D    0x02
+#define PBUS_FLIGHTSTICK_SHIFT_R    0x01
+#define PBUS_FLIGHTSTICK_SHIFT_L    0x00
+#define PBUS_FLIGHTSTICK_SHIFT_P    0x07
+#define PBUS_FLIGHTSTICK_SHIFT_X    0x06
+#define PBUS_FLIGHTSTICK_SHIFT_LT   0x05
+#define PBUS_FLIGHTSTICK_SHIFT_RT   0x04
 
-#define PBUS_LG_SHIFT_TRIGGER 7
-#define PBUS_LG_SHIFT_SERVICE 6
-#define PBUS_LG_SHIFT_COINS   5
-#define PBUS_LG_SHIFT_START   4
-#define PBUS_LG_SHIFT_HOLSTER 3
-#define PBUS_LG_SHIFT_OPTION  3
+#define PBUS_MOUSE_SHIFT_LEFT       7
+#define PBUS_MOUSE_SHIFT_MIDDLE     6
+#define PBUS_MOUSE_SHIFT_RIGHT      5
+#define PBUS_MOUSE_SHIFT_SHIFT      4
+
+#define PBUS_LG_SHIFT_TRIGGER       7
+#define PBUS_LG_SHIFT_SERVICE       6
+#define PBUS_LG_SHIFT_COINS         5
+#define PBUS_LG_SHIFT_START         4
+#define PBUS_LG_SHIFT_HOLSTER       3
+#define PBUS_LG_SHIFT_OPTION        3
 
 #define PBUS_ORBATAK_SHIFT_COIN_P1  5
 #define PBUS_ORBATAK_SHIFT_COIN_P2  4
@@ -51,76 +65,94 @@ typedef struct pbus_s pbus_t;
 
 static pbus_t PBUS = {0,{0}};
 
-/*
-  It's possible that with multiple joypads should be packed into
-  32bits and intertwined in the format of:
-
-  CDAB GHEF
-
-  A = P1 MSB
-  B = P1 LSB
-  C = P2 MSB
-  D = P2 LSB
-  etc.
-*/
-static
 void
-pbus_add_joypad(const freedo_pbus_joypad_t *joypad_,
-                uint8_t                    *buf_)
+freedo_pbus_add_joypad(const freedo_pbus_joypad_t *jp_)
 {
-  buf_[3] = ((PBUS_JOYPAD_ID)                      |
-             (joypad_->d  << PBUS_JOYPAD_SHIFT_D)  |
-             (joypad_->u  << PBUS_JOYPAD_SHIFT_U)  |
-             (joypad_->r  << PBUS_JOYPAD_SHIFT_R)  |
-             (joypad_->l  << PBUS_JOYPAD_SHIFT_L)  |
-             (joypad_->a  << PBUS_JOYPAD_SHIFT_A));
-  buf_[2] = ((joypad_->b  << PBUS_JOYPAD_SHIFT_B)  |
-             (joypad_->c  << PBUS_JOYPAD_SHIFT_C)  |
-             (joypad_->p  << PBUS_JOYPAD_SHIFT_P)  |
-             (joypad_->x  << PBUS_JOYPAD_SHIFT_X)  |
-             (joypad_->rt << PBUS_JOYPAD_SHIFT_RT) |
-             (joypad_->lt << PBUS_JOYPAD_SHIFT_LT));
-  buf_[1] = 0xFF;
-  buf_[0] = 0xFF;
+  if((PBUS.idx + 2) >= PBUS_BUF_SIZE)
+    return;
+
+  PBUS.buf[PBUS.idx++] = ((PBUS_JOYPAD_ID)                  |
+                          (jp_->d  << PBUS_JOYPAD_SHIFT_D)  |
+                          (jp_->u  << PBUS_JOYPAD_SHIFT_U)  |
+                          (jp_->r  << PBUS_JOYPAD_SHIFT_R)  |
+                          (jp_->l  << PBUS_JOYPAD_SHIFT_L)  |
+                          (jp_->a  << PBUS_JOYPAD_SHIFT_A));
+  PBUS.buf[PBUS.idx++] = ((jp_->b  << PBUS_JOYPAD_SHIFT_B)  |
+                          (jp_->c  << PBUS_JOYPAD_SHIFT_C)  |
+                          (jp_->p  << PBUS_JOYPAD_SHIFT_P)  |
+                          (jp_->x  << PBUS_JOYPAD_SHIFT_X)  |
+                          (jp_->rt << PBUS_JOYPAD_SHIFT_RT) |
+                          (jp_->lt << PBUS_JOYPAD_SHIFT_LT));
 }
 
-static
 void
-pbus_add_flightstick(const freedo_pbus_flightstick_t *fs_,
-                     uint8_t                         *buf_)
+freedo_pbus_add_flightstick(const freedo_pbus_flightstick_t *fs_)
 {
-  /* TODO */
+  uint8_t x;
+  uint8_t y;
+  uint8_t z;
+
+  if((PBUS.idx + 9) >= PBUS_BUF_SIZE)
+    return;
+
+  x = ((fs_->h_pos + 32768) / (65536 / 256));
+  y = ((fs_->v_pos + 32768) / (65536 / 256));
+  z = ((fs_->z_pos + 32768) / (65536 / 256));
+
+  PBUS.buf[PBUS.idx++] = PBUS_FLIGHTSTICK_ID_0;
+  PBUS.buf[PBUS.idx++] = PBUS_FLIGHTSTICK_ID_1;
+  PBUS.buf[PBUS.idx++] = 0x08;
+  PBUS.buf[PBUS.idx++] = x;
+
+  PBUS.buf[PBUS.idx++] = (y >> 2);
+  PBUS.buf[PBUS.idx++] = (((y & 0x03) << 6) | ((z & 0xF0) >> 4));
+  PBUS.buf[PBUS.idx++] = (((z & 0x0F) << 4) | 0x02);
+  PBUS.buf[PBUS.idx++] = ((fs_->fire << PBUS_FLIGHTSTICK_SHIFT_FIRE) |
+                          (fs_->a    << PBUS_FLIGHTSTICK_SHIFT_A)    |
+                          (fs_->b    << PBUS_FLIGHTSTICK_SHIFT_B)    |
+                          (fs_->c    << PBUS_FLIGHTSTICK_SHIFT_C)    |
+                          (fs_->u    << PBUS_FLIGHTSTICK_SHIFT_U)    |
+                          (fs_->d    << PBUS_FLIGHTSTICK_SHIFT_D)    |
+                          (fs_->r    << PBUS_FLIGHTSTICK_SHIFT_R)    |
+                          (fs_->l    << PBUS_FLIGHTSTICK_SHIFT_L));
+
+  PBUS.buf[PBUS.idx++] = ((fs_->p    << PBUS_FLIGHTSTICK_SHIFT_P)    |
+                          (fs_->x    << PBUS_FLIGHTSTICK_SHIFT_X)    |
+                          (fs_->lt   << PBUS_FLIGHTSTICK_SHIFT_LT)   |
+                          (fs_->rt   << PBUS_FLIGHTSTICK_SHIFT_RT));
 }
 
-static
 void
-pbus_add_mouse(const freedo_pbus_mouse_t *mouse_,
-               uint8_t                   *buf_)
+freedo_pbus_add_mouse(const freedo_pbus_mouse_t *mouse_)
 {
-  buf_[3] = PBUS_MOUSE_ID;
-  buf_[2] = ((mouse_->left   << PBUS_MOUSE_SHIFT_LEFT)   |
-             (mouse_->middle << PBUS_MOUSE_SHIFT_MIDDLE) |
-             (mouse_->right  << PBUS_MOUSE_SHIFT_RIGHT)  |
-             (mouse_->shift  << PBUS_MOUSE_SHIFT_SHIFT) |
-             ((mouse_->y & 0x3C0) >> 6));
-  buf_[1] = (((mouse_->y & 0x03F) << 2) |
-             ((mouse_->x & 0x300) >> 8));
-  buf_[0] = (mouse_->x & 0xFF);
+  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
+    return;
+
+  PBUS.buf[PBUS.idx++] = PBUS_MOUSE_ID;
+  PBUS.buf[PBUS.idx++] = ((mouse_->left   << PBUS_MOUSE_SHIFT_LEFT)   |
+                          (mouse_->middle << PBUS_MOUSE_SHIFT_MIDDLE) |
+                          (mouse_->right  << PBUS_MOUSE_SHIFT_RIGHT)  |
+                          (mouse_->shift  << PBUS_MOUSE_SHIFT_SHIFT)  |
+                          ((mouse_->y & 0x3C0) >> 6));
+  PBUS.buf[PBUS.idx++] = (((mouse_->y & 0x03F) << 2) |
+                          ((mouse_->x & 0x300) >> 8));
+  PBUS.buf[PBUS.idx++] = (mouse_->x & 0xFF);
 }
 
 /*
   The algo below is derived from FreeDO's lightgun.cpp. It's not clear
   where all the constants come from or refer to.
 */
-static
 void
-pbus_add_lightgun(const freedo_pbus_lightgun_t *lg_,
-                  uint8_t                      *buf_)
+freedo_pbus_add_lightgun(const freedo_pbus_lightgun_t *lg_)
 {
   int32_t x;
   int32_t y;
   int32_t r;
   uint8_t trigger;
+
+  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
+    return;
 
   trigger = lg_->trigger;
   if(lg_->reload)
@@ -139,22 +171,23 @@ pbus_add_lightgun(const freedo_pbus_lightgun_t *lg_,
 
   r = (((y * 794.386) + x) / 5.0);
 
-  buf_[3] = PBUS_LIGHTGUN_ID;
-  buf_[2] = ((trigger      << PBUS_LG_SHIFT_TRIGGER) |
-             (lg_->option  << PBUS_LG_SHIFT_OPTION)  |
-             ((r & 0x10000) >> 16));
-  buf_[1] = ((r & 0xFF00) >> 8);
-  buf_[0] = (r & 0xFF);
+  PBUS.buf[PBUS.idx++] = PBUS_LIGHTGUN_ID;
+  PBUS.buf[PBUS.idx++] = ((trigger      << PBUS_LG_SHIFT_TRIGGER) |
+                          (lg_->option  << PBUS_LG_SHIFT_OPTION)  |
+                          ((r & 0x10000) >> 16));
+  PBUS.buf[PBUS.idx++] = ((r & 0xFF00) >> 8);
+  PBUS.buf[PBUS.idx++] = (r & 0xFF);
 }
 
-static
 void
-pbus_add_arcade_lightgun(const freedo_pbus_arcade_lightgun_t *lg_,
-                         uint8_t                             *buf_)
+freedo_pbus_add_arcade_lightgun(const freedo_pbus_arcade_lightgun_t *lg_)
 {
   int32_t x;
   int32_t y;
   int32_t r;
+
+  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
+    return;
 
   if(lg_->holster)
     {
@@ -171,89 +204,15 @@ pbus_add_arcade_lightgun(const freedo_pbus_arcade_lightgun_t *lg_,
 
   r = (((y * 794.386) + x) / 5.0);
 
-  buf_[3] = PBUS_LIGHTGUN_ID;
-  buf_[2] = ((lg_->trigger << PBUS_LG_SHIFT_TRIGGER) |
-             (lg_->service << PBUS_LG_SHIFT_SERVICE) |
-             (lg_->coins   << PBUS_LG_SHIFT_COINS)   |
-             (lg_->start   << PBUS_LG_SHIFT_START)   |
-             (lg_->holster << PBUS_LG_SHIFT_HOLSTER) |
-             ((r & 0x10000) >> 16));
-  buf_[1] = ((r & 0xFF00) >> 8);
-  buf_[0] = (r & 0xFF);
-}
-
-static
-void
-pbus_add_orbatak_trackball(const freedo_pbus_orbatak_trackball_t *tb_,
-                           uint8_t                               *buf_)
-{
-  buf_[3] = PBUS_ORBATAK_TRACKBALL_ID;
-  buf_[2] = ((tb_->y & 0x3C0) >> 6);
-  buf_[1] = (((tb_->y & 0x03F) << 2) |
-             ((tb_->x & 0x300) >> 8));
-  buf_[0] = (tb_->x & 0xFF);
-
-  buf_[7] = PBUS_ORBATAK_BUTTONS_ID;
-  buf_[6] = 0;
-  buf_[5] = ((tb_->coin_p1  << PBUS_ORBATAK_SHIFT_COIN_P1)  |
-             (tb_->coin_p2  << PBUS_ORBATAK_SHIFT_COIN_P2)  |
-             (tb_->start_p1 << PBUS_ORBATAK_SHIFT_START_P1) |
-             (tb_->start_p2 << PBUS_ORBATAK_SHIFT_START_P2) |
-             (tb_->service  << PBUS_ORBATAK_SHIFT_SERVICE));
-  buf_[4] = 0;
-}
-
-void
-freedo_pbus_add_joypad(const freedo_pbus_joypad_t *joypad_)
-{
-  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
-    return;
-
-  pbus_add_joypad(joypad_,&PBUS.buf[PBUS.idx]);
-  PBUS.idx += 4;
-}
-
-void
-freedo_pbus_add_mouse(const freedo_pbus_mouse_t *mouse_)
-{
-  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
-    return;
-
-  pbus_add_mouse(mouse_,&PBUS.buf[PBUS.idx]);
-  PBUS.idx += 4;
-}
-
-void
-freedo_pbus_add_lightgun(const freedo_pbus_lightgun_t *lg_)
-{
-  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
-    return;
-
-  pbus_add_lightgun(lg_,&PBUS.buf[PBUS.idx]);
-  PBUS.idx += 4;
-}
-
-void
-freedo_pbus_add_arcade_lightgun(const freedo_pbus_arcade_lightgun_t *lg_)
-{
-  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
-    return;
-
-  pbus_add_arcade_lightgun(lg_,&PBUS.buf[PBUS.idx]);
-  PBUS.idx += 4;
-}
-
-void
-freedo_pbus_add_flightstick(const freedo_pbus_flightstick_t *fs_)
-{
-  /* TODO */
-  return;
-
-  if((PBUS.idx + 8) >= PBUS_BUF_SIZE)
-    return;
-
-  pbus_add_flightstick(fs_,&PBUS.buf[PBUS.idx]);
-  PBUS.idx += 8;
+  PBUS.buf[PBUS.idx++] = PBUS_LIGHTGUN_ID;
+  PBUS.buf[PBUS.idx++] = ((lg_->trigger << PBUS_LG_SHIFT_TRIGGER) |
+                          (lg_->service << PBUS_LG_SHIFT_SERVICE) |
+                          (lg_->coins   << PBUS_LG_SHIFT_COINS)   |
+                          (lg_->start   << PBUS_LG_SHIFT_START)   |
+                          (lg_->holster << PBUS_LG_SHIFT_HOLSTER) |
+                          ((r & 0x10000) >> 16));
+  PBUS.buf[PBUS.idx++] = ((r & 0xFF00) >> 8);
+  PBUS.buf[PBUS.idx++] = (r & 0xFF);
 }
 
 void
@@ -262,8 +221,20 @@ freedo_pbus_add_orbatak_trackball(const freedo_pbus_orbatak_trackball_t *tb_)
   if((PBUS.idx + 8) >= PBUS_BUF_SIZE)
     return;
 
-  pbus_add_orbatak_trackball(tb_,&PBUS.buf[PBUS.idx]);
-  PBUS.idx += 8;
+  PBUS.buf[PBUS.idx++] = PBUS_ORBATAK_TRACKBALL_ID;
+  PBUS.buf[PBUS.idx++] = ((tb_->y & 0x3C0) >> 6);
+  PBUS.buf[PBUS.idx++] = (((tb_->y & 0x03F) << 2) |
+                          ((tb_->x & 0x300) >> 8));
+  PBUS.buf[PBUS.idx++] = (tb_->x & 0xFF);
+
+  PBUS.buf[PBUS.idx++] = PBUS_ORBATAK_BUTTONS_ID;
+  PBUS.buf[PBUS.idx++] = 0;
+  PBUS.buf[PBUS.idx++] = ((tb_->coin_p1  << PBUS_ORBATAK_SHIFT_COIN_P1)  |
+                          (tb_->coin_p2  << PBUS_ORBATAK_SHIFT_COIN_P2)  |
+                          (tb_->start_p1 << PBUS_ORBATAK_SHIFT_START_P1) |
+                          (tb_->start_p2 << PBUS_ORBATAK_SHIFT_START_P2) |
+                          (tb_->service  << PBUS_ORBATAK_SHIFT_SERVICE));
+  PBUS.buf[PBUS.idx++] = 0;
 }
 
 void*
@@ -276,6 +247,15 @@ uint32_t
 freedo_pbus_size(void)
 {
   return PBUS.idx;
+}
+
+void
+freedo_pbus_pad(void)
+{
+  int i;
+
+  for(i = 0; ((i < 8) && (PBUS.idx < PBUS_BUF_SIZE)); i++)
+    PBUS.buf[PBUS.idx++] = 0xFF;
 }
 
 void

--- a/libfreedo/freedo_pbus.c
+++ b/libfreedo/freedo_pbus.c
@@ -22,7 +22,6 @@
 #define PBUS_JOYPAD_SHIFT_R        0x02
 #define PBUS_JOYPAD_SHIFT_U        0x03
 #define PBUS_JOYPAD_SHIFT_D        0x04
-#define PBUS_JOYPAD_CONNECTED_MASK 0x80
 
 #define PBUS_MOUSE_SHIFT_LEFT   7
 #define PBUS_MOUSE_SHIFT_MIDDLE 6
@@ -52,25 +51,37 @@ typedef struct pbus_s pbus_t;
 
 static pbus_t PBUS = {0,{0}};
 
+/*
+  It's possible that with multiple joypads should be packed into
+  32bits and intertwined in the format of:
+
+  CDAB GHEF
+
+  A = P1 MSB
+  B = P1 LSB
+  C = P2 MSB
+  D = P2 LSB
+  etc.
+*/
 static
 void
 pbus_add_joypad(const freedo_pbus_joypad_t *joypad_,
                 uint8_t                    *buf_)
 {
-  buf_[0] = 0x00;
-  buf_[1] = PBUS_JOYPAD_ID;
-  buf_[2] = ((joypad_->lt << PBUS_JOYPAD_SHIFT_LT) |
-             (joypad_->rt << PBUS_JOYPAD_SHIFT_RT) |
-             (joypad_->x  << PBUS_JOYPAD_SHIFT_X)  |
-             (joypad_->p  << PBUS_JOYPAD_SHIFT_P)  |
-             (joypad_->c  << PBUS_JOYPAD_SHIFT_C)  |
-             (joypad_->b  << PBUS_JOYPAD_SHIFT_B));
-  buf_[3] = ((joypad_->a  << PBUS_JOYPAD_SHIFT_A)  |
-             (joypad_->l  << PBUS_JOYPAD_SHIFT_L)  |
-             (joypad_->r  << PBUS_JOYPAD_SHIFT_R)  |
-             (joypad_->u  << PBUS_JOYPAD_SHIFT_U)  |
+  buf_[3] = ((PBUS_JOYPAD_ID)                      |
              (joypad_->d  << PBUS_JOYPAD_SHIFT_D)  |
-             (PBUS_JOYPAD_CONNECTED_MASK));
+             (joypad_->u  << PBUS_JOYPAD_SHIFT_U)  |
+             (joypad_->r  << PBUS_JOYPAD_SHIFT_R)  |
+             (joypad_->l  << PBUS_JOYPAD_SHIFT_L)  |
+             (joypad_->a  << PBUS_JOYPAD_SHIFT_A));
+  buf_[2] = ((joypad_->b  << PBUS_JOYPAD_SHIFT_B)  |
+             (joypad_->c  << PBUS_JOYPAD_SHIFT_C)  |
+             (joypad_->p  << PBUS_JOYPAD_SHIFT_P)  |
+             (joypad_->x  << PBUS_JOYPAD_SHIFT_X)  |
+             (joypad_->rt << PBUS_JOYPAD_SHIFT_RT) |
+             (joypad_->lt << PBUS_JOYPAD_SHIFT_LT));
+  buf_[1] = 0xFF;
+  buf_[0] = 0xFF;
 }
 
 static

--- a/libfreedo/freedo_pbus.h
+++ b/libfreedo/freedo_pbus.h
@@ -18,6 +18,26 @@ struct freedo_pbus_joypad_s
   uint8_t rt;
 };
 
+struct freedo_pbus_flightstick_s
+{
+  uint8_t fire;
+  uint8_t a;
+  uint8_t b;
+  uint8_t c;
+  uint8_t u;
+  uint8_t d;
+  uint8_t l;
+  uint8_t r;
+  uint8_t p;
+  uint8_t x;
+  uint8_t lt;
+  uint8_t rt;
+
+  int32_t h_pos;
+  int32_t v_pos;
+  int32_t z_pos;
+};
+
 struct freedo_pbus_mouse_s
 {
   uint8_t left;
@@ -51,35 +71,16 @@ struct freedo_pbus_arcade_lightgun_s
   int16_t y;
 };
 
-struct freedo_pbus_flightstick_s
-{
-  uint8_t fire;
-  uint8_t a;
-  uint8_t b;
-  uint8_t c;
-  uint8_t u;
-  uint8_t d;
-  uint8_t l;
-  uint8_t r;
-  uint8_t p;
-  uint8_t s;
-  uint8_t lt;
-  uint8_t rt;
-
-  int32_t h_pos;
-  int32_t v_pos;
-  int32_t z_pos;
-};
-
 struct freedo_pbus_orbatak_trackball_s
 {
-  int16_t x;
-  int16_t y;
   uint8_t start_p1;
   uint8_t start_p2;
   uint8_t coin_p1;
   uint8_t coin_p2;
   uint8_t service;
+
+  int16_t x;
+  int16_t y;
 };
 
 typedef struct freedo_pbus_joypad_s freedo_pbus_joypad_t;
@@ -91,6 +92,7 @@ typedef struct freedo_pbus_orbatak_trackball_s freedo_pbus_orbatak_trackball_t;
 
 void*    freedo_pbus_buf(void);
 uint32_t freedo_pbus_size(void);
+void     freedo_pbus_pad(void);
 void     freedo_pbus_reset(void);
 void     freedo_pbus_add_joypad(const freedo_pbus_joypad_t *joypad_);
 void     freedo_pbus_add_flightstick(const freedo_pbus_flightstick_t *fs_);

--- a/libfreedo/pbus.txt
+++ b/libfreedo/pbus.txt
@@ -66,9 +66,36 @@ MSB -> LSB
 1bit: X
 1bit: right trigger
 1bit: left trigger
-2bit: unused
-8bit: set (0xFF)
-8bit: set (0xFF)
+2bit: unused / 0
+
+
+### FLIGHTSTICK
+
+MSB -> LSB
+
+* 8bit: identifier 0 (0x01)
+* 8bit: identifier 1 (0x7B)
+* 8bit: length? (0x08)
+* 8bit: horizontal position
+* 2bit: 0
+* 8bit: vertical position
+* 2bit: 0
+* 8bit: depth position
+* 4bit: 0x02 (unsure what this means)
+* 1bit: trigger / fire
+* 1bit: A
+* 1bit: B
+* 1bit: C
+* 1bit: up
+* 1bit: down
+* 1bit: right
+* 1bit: left
+* 1bit: P
+* 1bit: X
+* 1bit: left trigger
+* 1bit: right trigger
+* 4bit: 0
+
 
 ### MOUSE
 
@@ -81,6 +108,7 @@ MSB -> LSB
 * 1bit: shift button
 * 10bit: X delta (signed)
 * 10bit: Y delta (signed)
+
 
 ### LIGHTGUN
 
@@ -139,6 +167,7 @@ x = ((((10 * counter) % NTSC_DEFAULT_YSCANTIME) * NTSC_WIDTH) /
 y = ((10 * counter) / NTSC_DEFAULT_YSCANTIME);
 ```
 
+
 ### ORBATAK TRACKBALL
 
 Orbatak uses two different devices. The trackballs are just mice as
@@ -156,6 +185,7 @@ MSB -> LSB
 1bit: start (p1)
 1bit: service
 8bit: 0x00
+
 
 ## Device Usage In Games
 
@@ -200,9 +230,7 @@ MSB -> LSB
 * Phoenix 3 (1995)
 * PO'ed (1995)
 * Return Fire (1995)
-* Road & Track Presents: The Need for Speed (1994)
 * Scramble Cobra (1995)
-* Shockwave: Operation Jumpgate (1995)
 * Shockwave 2: Beyond The Gate (1995)
 * Space Ace (1995)
 * Star Fighter (1996)

--- a/libfreedo/pbus.txt
+++ b/libfreedo/pbus.txt
@@ -1,3 +1,5 @@
+# PBUS
+
 The PBUS (player bus) is not at all well documented. There exists
 the patent WO09410636A1 "PLAYER BUS APPARATUS AND METHOD" which was
 filed on 1992-02-11. The primary details of the protocol can be
@@ -37,12 +39,41 @@ found in pages 21 - 23.
 > immediately following the 4 bit identification code. A string of
 > zeros indicate the end of input data into the system 100 device.
 
-However, information from the original FreeDO release does not seem
-to match with the specifics of the patent.
+However, information from the original FreeDO release and later
+discovered does not match with the specifics of the patent.
 
-MOUSE:
+## Device Data Formats
+
+### JOYPAD
+
+The joypad's data layout is clear but less so in regards to it's
+layout in the stream. 3DO's SDK indicates the ID is 0x80. Unlike other
+device IDs it appears the joypad's ID is embedded. In the FreeDO
+source it was questionably referred to as a connection bit.
 
 MSB -> LSB
+
+1bit: set, the high order bit from the ID (0x80)
+2bit: unused, unset, part of the joypad mask
+1bit: down
+1bit: up
+1bit: right
+1bit: left
+1bit: A
+1bit: B
+1bit: C
+1bit: P
+1bit: X
+1bit: right trigger
+1bit: left trigger
+2bit: unused
+8bit: set (0xFF)
+8bit: set (0xFF)
+
+### MOUSE
+
+MSB -> LSB
+
 * 8bit: identifier (0x49)
 * 1bit: left button
 * 1bit: middle button
@@ -51,32 +82,7 @@ MSB -> LSB
 * 10bit: X delta (signed)
 * 10bit: Y delta (signed)
 
-JOYPAD:
-
-The joypad's data layout is clear but less so in regards to it's
-layout in the stream. The identifier seems necessary but other
-values work (3DO's SDK indicates the ID is 0x80 but FreeDO was using
-0x48). Perhaps the ID is really a mask and really the 'connectivity'
-bit. It's not clear from the 3DO SDK event.h file what the raw data
-layout is.
-
-LSB -> MSB
-2bit: unknown / unused
-1bit: left trigger
-1bit: right trigger
-1bit: X
-1bit: P
-1bit: C
-1bit: B
-1bit: A
-1bit: left
-1bit: right
-1bit: up
-1bit: down
-2bit: unknown / unused
-1bit: connectivity?
-
-LIGHTGUN:
+### LIGHTGUN
 
 x = 0 - 639
 y = 0 - 240
@@ -102,6 +108,7 @@ appears to be represented as y = 0 and x = ~20 - ~640.
 
 According to the 3DO SDK's lightgun.c:
 
+```
 DESCRIPTION OF LIGHTGUN HARDWARE
 --------------------------------
 The lightgun is not capable of returning an (X, Y) position value when
@@ -130,12 +137,14 @@ scan-beam begings drawing to the first pixel on the first scan line
 x = ((((10 * counter) % NTSC_DEFAULT_YSCANTIME) * NTSC_WIDTH) /
      (NTSC_DEFAULT_XSCANTIME * 10));
 y = ((10 * counter) / NTSC_DEFAULT_YSCANTIME);
+```
 
-ORBATAK TRACKBALL:
+### ORBATAK TRACKBALL
 
 Orbatak uses two different devices. The trackballs are just mice as
 described above. The buttons (coins, start, service) are managed via
-the "SILLY_CONTROL_PAD" as defined in the 3DO SDK (event.h).
+the "SILLY_CONTROL_PAD" as defined in the 3DO SDK (event.h) or in the
+least uses the same identifier.
 
 MSB -> LSB
 8bit: identifier (0xC0)
@@ -148,7 +157,9 @@ MSB -> LSB
 1bit: service
 8bit: 0x00
 
-Games supporting 3DO mouse:
+## Device Usage In Games
+
+### Games supporting 3DO mouse
 
 * Crime Patrol (1993)
 * Cyberdillo (1996)
@@ -165,7 +176,7 @@ Games supporting 3DO mouse:
 * World Cup Golf: Hyatt Dorado Beach (1994)
 * Zhadnost: The People's Party (1995)
 
-Games supporting GAMECON (3DO lightgun):
+### Games supporting GAMECON (3DO lightgun)
 
 * Corpse Killer (1994) (1 Player)
 * Crime Patrol (1993) (1 Player or 2 Players simultaneously)
@@ -178,7 +189,7 @@ Games supporting GAMECON (3DO lightgun):
 * The Last Bounty Hunter (1995) (1 Player or 2 Players simultaneously)
 * Who Shot Johnny Rock (1995) (1 Player or 2 Players simultaneously)
 
-Games supporting 3DO flight stick:
+### Games supporting 3DO flight stick
 
 * Blade Force (1995)
 * Cyberia (1996)

--- a/libretro.c
+++ b/libretro.c
@@ -155,6 +155,7 @@ retro_environment_set_variables(void)
       { "4do_hack_timing_5",        "Timing Hack 5 (Microcosm); disabled|enabled" },
       { "4do_hack_timing_6",        "Timing Hack 6 (Alone in the Dark); disabled|enabled" },
       { "4do_hack_graphics_step_y", "Graphics Step Y Hack (Samurai Shodown); disabled|enabled" },
+      { "4do_madam_matrix_engine",  "MADAM Matrix Engine; hardware|software" },
       { "4do_kprint",               "3DO debugging output (stderr); disabled|enabled" },
       { NULL, NULL },
     };
@@ -586,13 +587,36 @@ check_option_4do_active_devices(void)
 
 static
 void
+check_option_4do_madam_matrix_engine(void)
+{
+  int rv;
+  struct retro_variable var;
+
+  var.key   = "4do_madam_matrix_engine";
+  var.value = NULL;
+
+  rv = retro_environment_cb(RETRO_ENVIRONMENT_GET_VARIABLE,&var);
+  if(rv && var.value)
+    {
+      if(!strcmp(var.value,"software"))
+        freedo_madam_me_mode_software();
+      else
+        freedo_madam_me_mode_hardware();
+    }
+}
+
+static
+void
 check_option_4do_kprint(void)
 {
   int rv;
 
   rv = option_enabled("4do_kprint");
 
-  freedo_madam_kprint_set(rv);
+  if(rv)
+    freedo_madam_kprint_enable();
+  else
+    freedo_madam_kprint_disable();
 }
 
 static
@@ -610,6 +634,7 @@ check_options(void)
   check_option_set_reset_bits("4do_hack_timing_6",&FIXMODE,FIX_BIT_TIMING_6);
   check_option_set_reset_bits("4do_hack_graphics_step_y",&FIXMODE,FIX_BIT_GRAPHICS_STEP_Y);
   check_option_4do_kprint();
+  check_option_4do_madam_matrix_engine();
 }
 
 void

--- a/libretro.c
+++ b/libretro.c
@@ -13,6 +13,7 @@
 #include "lr_input.h"
 #include "lr_input_crosshair.h"
 #include "lr_input_descs.h"
+#include "disk_control.h"
 #include "nvram.h"
 #include "retro_callbacks.h"
 #include "retro_cdimage.h"
@@ -751,21 +752,15 @@ retro_load_game(const struct retro_game_info *info_)
                           "[4DO]: XRGB8888 is not supported.\n");
       return false;
     }
-
-  cdimage_set_sector(0);
   audio_reset_sample_buffer();
 
-  if(info_)
-    {
-      rv = retro_cdimage_open(info_->path,&CDIMAGE);
-      if(rv == -1)
-        {
-          retro_log_printf_cb(RETRO_LOG_ERROR,
-                              "[4DO]: failure opening image - %s\n",
-                              info_->path);
-          return false;
-        }
-    }
+  if (info_ == NULL || info_->path == NULL)
+  {
+    retro_log_printf_cb(RETRO_LOG_ERROR, "info_->path required\n");
+    return false;
+  }
+  if ((rv = disk_control_open_file(info_->path)) == -1)
+    return false;
 
   check_options();
   video_init();
@@ -800,6 +795,7 @@ retro_unload_game(void)
     retro_nvram_save(freedo_arm_nvram_get());
 
   freedo_3do_destroy();
+  disk_control_cleanup();
 
   retro_cdimage_close(&CDIMAGE);
 
@@ -869,11 +865,11 @@ retro_init(void)
 
   retro_environment_cb(RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL,&level);
   retro_environment_cb(RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS,&serialization_quirks);
-  retro_environment_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE, &disk_control_cb);
+  retro_environment_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE,&disk_control_cb);
 
-  freedo_cdrom_set_callbacks(cdimage_get_size,
-                             cdimage_set_sector,
-                             cdimage_read_sector);
+  freedo_cdrom_set_callbacks(disk_image_get_size,
+                             disk_image_set_sector,
+                             disk_image_read_sector);
 }
 
 void
@@ -897,6 +893,7 @@ retro_reset(void)
   freedo_3do_init(libfreedo_callback);
   load_rom1();
   load_rom2();
+  disk_control_get()->current_sector = 0;
 
   nvram_init(freedo_arm_nvram_get());
   if(check_option_nvram_shared())

--- a/libretro.c
+++ b/libretro.c
@@ -714,11 +714,14 @@ load_rom2(void)
   int64_t  size;
   int64_t  rv;
 
-  if((FONT == NULL) || (FONT == freedo_bios_font_end()))
-    return 0;
-
   rom  = freedo_arm_rom2_get();
   size = freedo_arm_rom2_size();
+
+  if((FONT == NULL) || (FONT == freedo_bios_font_end()))
+    {
+      memset(rom,0,size);
+      return 0;
+    }
 
   rv = read_file_from_system_directory(FONT->filename,rom,size);
   if(rv < 0)

--- a/libretro.c
+++ b/libretro.c
@@ -349,7 +349,7 @@ retro_get_system_info(struct retro_system_info *info_)
   info_->library_name     = "4DO";
   info_->library_version  = "1.3.2.4" GIT_VERSION;
   info_->need_fullpath    = true;
-  info_->valid_extensions = "iso|bin|chd|cue";
+  info_->valid_extensions = "iso|bin|chd|cue|m3u";
 }
 
 void
@@ -869,6 +869,7 @@ retro_init(void)
 
   retro_environment_cb(RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL,&level);
   retro_environment_cb(RETRO_ENVIRONMENT_SET_SERIALIZATION_QUIRKS,&serialization_quirks);
+  retro_environment_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE, &disk_control_cb);
 
   freedo_cdrom_set_callbacks(cdimage_get_size,
                              cdimage_set_sector,

--- a/lr_input.c
+++ b/lr_input.c
@@ -114,7 +114,7 @@ lr_input_poll_flightstick(const int port_)
   fs.l    = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_LEFT);
   fs.r    = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_RIGHT);
   fs.p    = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_START);
-  fs.s    = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_SELECT);
+  fs.x    = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_SELECT);
   fs.lt   = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_L);
   fs.rt   = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_R);
 

--- a/retro_cdimage.c
+++ b/retro_cdimage.c
@@ -15,10 +15,12 @@ static
 void
 cdimage_set_size_and_offset(cdimage_t *cd_,
                             const int  size_,
-                            const int  offset_)
+                            const int  offset_,
+                            const char *path_)
 {
   cd_->sector_size   = size_;
   cd_->sector_offset = offset_;
+  cd_->filename = strdup(path_);
 }
 
 int
@@ -41,9 +43,9 @@ retro_cdimage_open_chd(const char *path_,
 
   /* MODE1 */
   if(!memcmp(buf,pattern,sizeof(pattern)))
-    cdimage_set_size_and_offset(cdimage_,2448,0);
+    cdimage_set_size_and_offset(cdimage_,2448,0,path_);
   else /* MODE1_RAW */
-    cdimage_set_size_and_offset(cdimage_,2352,16);
+    cdimage_set_size_and_offset(cdimage_,2352,16,path_);
 
   return 0;
 }
@@ -62,11 +64,11 @@ retro_cdimage_open_iso(const char *path_,
 
   size = intfstream_get_size(cdimage_->fp);
   if((size % 2048) == 0)
-    cdimage_set_size_and_offset(cdimage_,2048,0);
+    cdimage_set_size_and_offset(cdimage_,2048,0,path_);
   else if((size % 2352) == 0)
-    cdimage_set_size_and_offset(cdimage_,2352,16);
+    cdimage_set_size_and_offset(cdimage_,2352,16,path_);
   else
-    cdimage_set_size_and_offset(cdimage_,2048,0);
+    cdimage_set_size_and_offset(cdimage_,2048,0,path_);
 
   return 0;
 }
@@ -108,17 +110,17 @@ retro_cdimage_open_cue(const char *path_,
   switch(cue_file->cd_format)
     {
     case MODE1_2048:
-      cdimage_set_size_and_offset(cdimage_,2048,0);
+      cdimage_set_size_and_offset(cdimage_,2048,0,path_);
       break;
     case MODE1_2352:
-      cdimage_set_size_and_offset(cdimage_,2352,16);
+      cdimage_set_size_and_offset(cdimage_,2352,16,path_);
       break;
     case MODE2_2352:
-      cdimage_set_size_and_offset(cdimage_,2352,24);
+      cdimage_set_size_and_offset(cdimage_,2352,24,path_);
       break;
     default:
     case CUE_MODE_UNKNOWN:
-      cdimage_set_size_and_offset(cdimage_,2048,0);
+      cdimage_set_size_and_offset(cdimage_,2048,0,path_);
       break;
     }
 
@@ -137,10 +139,9 @@ retro_cdimage_open(const char *path_,
   if(ext == NULL)
     return -1;
 
-
   if(!strcasecmp(ext,"chd"))
     return retro_cdimage_open_chd(path_,cdimage_);
-  if(!strcasecmp(ext,"cue") || !strncasecmp(ext, "cd", 2))
+  if(!strcasecmp(ext,"cue"))
     return retro_cdimage_open_cue(path_,cdimage_);
   if(!strcasecmp(ext,"iso"))
     return retro_cdimage_open_iso(path_,cdimage_);

--- a/retro_cdimage.c
+++ b/retro_cdimage.c
@@ -137,9 +137,10 @@ retro_cdimage_open(const char *path_,
   if(ext == NULL)
     return -1;
 
+
   if(!strcasecmp(ext,"chd"))
     return retro_cdimage_open_chd(path_,cdimage_);
-  if(!strcasecmp(ext,"cue"))
+  if(!strcasecmp(ext,"cue") || !strncasecmp(ext, "cd", 2))
     return retro_cdimage_open_cue(path_,cdimage_);
   if(!strcasecmp(ext,"iso"))
     return retro_cdimage_open_iso(path_,cdimage_);

--- a/retro_cdimage.h
+++ b/retro_cdimage.h
@@ -10,6 +10,7 @@ struct cdimage_s
   intfstream_t *fp;
   int           sector_size;
   int           sector_offset;
+  char         *filename;
 };
 
 typedef struct cdimage_s cdimage_t;


### PR DESCRIPTION
This gives the ability to swap disks for games loaded from a m3u playlist.  This is mostly just copied straight from the libretro-pcsx-rearmed repo.  As stated by @trapexit in #14 the hope is that having shared nvram will allow the disk swapping to work, for the time being, by switching disk with disk control, having the system reset, and leveraging shared saves.  I spent some time looking at the behavior of the existing emulator for the cdrom and the disk tray states do not appear to be fully implemented.  In the future I plan to look more into what is missing in freedo that will enable correct disk swapping behavior, but this should work for now to play games with multiple disks.