### PR TITLE
add flightstick support

### DIFF
--- a/libfreedo/endianness.h
+++ b/libfreedo/endianness.h
@@ -70,7 +70,7 @@
 
 #define is_little_endian() (0)
 #define swap32_if_little_endian(X) (X)
-#define swap32_array_if_little_endian(X,Y) 
+#define swap32_array_if_little_endian(X,Y)
 
 #else
 
@@ -90,8 +90,5 @@ swap32_array_if_little_endian(uint32_t *array_,
 }
 
 #endif /* IS_BIG_ENDIAN */
-
-#undef SWAP32
-#undef IS_BIG_ENDIAN
 
 #endif /* LIBFREEDO_ENDIANNESS_H_INCLUDED */

--- a/libfreedo/freedo_madam.c
+++ b/libfreedo/freedo_madam.c
@@ -37,6 +37,7 @@
 #include "freedo_vdlp.h"
 #include "hack_flags.h"
 #include "inline.h"
+#include "endianness.h"
 
 #include <math.h>
 #include <stdint.h>
@@ -1189,28 +1190,29 @@ static
 void
 DMAPBus(void)
 {
-  uint32_t  i;
   uint32_t *pbus_buf;
   int32_t   pbus_size;
 
   if((int32_t)MADAM.mregs[0x574] < 0)
     return;
 
+  freedo_pbus_pad();
+
   MADAM.mregs[0x574] -= 4;
   MADAM.mregs[0x570] += 4;
   MADAM.mregs[0x578] += 4;
 
-  i = 0;
-  pbus_buf = freedo_pbus_buf();
+  pbus_buf  = freedo_pbus_buf();
   pbus_size = freedo_pbus_size();
   while(((int32_t)MADAM.mregs[0x574] > 0) && (pbus_size > 0))
     {
-      freedo_io_write(MADAM.mregs[0x570],pbus_buf[i]);
-      MADAM.mregs[0x574] -= 4;
+      freedo_io_write(MADAM.mregs[0x570],
+                      swap32_if_little_endian(*pbus_buf));
+      pbus_buf++;
       pbus_size          -= 4;
+      MADAM.mregs[0x574] -= 4;
       MADAM.mregs[0x570] += 4;
       MADAM.mregs[0x578] += 4;
-      i++;
     }
 
   while((int32_t)MADAM.mregs[0x574] > 0)

--- a/libfreedo/freedo_pbus.c
+++ b/libfreedo/freedo_pbus.c
@@ -4,36 +4,50 @@
 
 #define PBUS_BUF_SIZE 256
 
-#define PBUS_FLIGHTSTICK_ID       0x01
-#define PBUS_JOYPAD_ID            0x80
-#define PBUS_MOUSE_ID             0x49
-#define PBUS_LIGHTGUN_ID          0x4D
-#define PBUS_ORBATAK_TRACKBALL_ID PBUS_MOUSE_ID
-#define PBUS_ORBATAK_BUTTONS_ID   0xC0
+#define PBUS_FLIGHTSTICK_ID_0       0x01
+#define PBUS_FLIGHTSTICK_ID_1       0x7B
+#define PBUS_JOYPAD_ID              0x80
+#define PBUS_MOUSE_ID               0x49
+#define PBUS_LIGHTGUN_ID            0x4D
+#define PBUS_ORBATAK_TRACKBALL_ID   PBUS_MOUSE_ID
+#define PBUS_ORBATAK_BUTTONS_ID     0xC0
 
-#define PBUS_JOYPAD_SHIFT_LT       0x02
-#define PBUS_JOYPAD_SHIFT_RT       0x03
-#define PBUS_JOYPAD_SHIFT_X        0x04
-#define PBUS_JOYPAD_SHIFT_P        0x05
-#define PBUS_JOYPAD_SHIFT_C        0x06
-#define PBUS_JOYPAD_SHIFT_B        0x07
-#define PBUS_JOYPAD_SHIFT_A        0x00
-#define PBUS_JOYPAD_SHIFT_L        0x01
-#define PBUS_JOYPAD_SHIFT_R        0x02
-#define PBUS_JOYPAD_SHIFT_U        0x03
-#define PBUS_JOYPAD_SHIFT_D        0x04
+#define PBUS_JOYPAD_SHIFT_LT        0x02
+#define PBUS_JOYPAD_SHIFT_RT        0x03
+#define PBUS_JOYPAD_SHIFT_X         0x04
+#define PBUS_JOYPAD_SHIFT_P         0x05
+#define PBUS_JOYPAD_SHIFT_C         0x06
+#define PBUS_JOYPAD_SHIFT_B         0x07
+#define PBUS_JOYPAD_SHIFT_A         0x00
+#define PBUS_JOYPAD_SHIFT_L         0x01
+#define PBUS_JOYPAD_SHIFT_R         0x02
+#define PBUS_JOYPAD_SHIFT_U         0x03
+#define PBUS_JOYPAD_SHIFT_D         0x04
 
-#define PBUS_MOUSE_SHIFT_LEFT   7
-#define PBUS_MOUSE_SHIFT_MIDDLE 6
-#define PBUS_MOUSE_SHIFT_RIGHT  5
-#define PBUS_MOUSE_SHIFT_SHIFT  4
+#define PBUS_FLIGHTSTICK_SHIFT_FIRE 0x07
+#define PBUS_FLIGHTSTICK_SHIFT_A    0x06
+#define PBUS_FLIGHTSTICK_SHIFT_B    0x05
+#define PBUS_FLIGHTSTICK_SHIFT_C    0x04
+#define PBUS_FLIGHTSTICK_SHIFT_U    0x03
+#define PBUS_FLIGHTSTICK_SHIFT_D    0x02
+#define PBUS_FLIGHTSTICK_SHIFT_R    0x01
+#define PBUS_FLIGHTSTICK_SHIFT_L    0x00
+#define PBUS_FLIGHTSTICK_SHIFT_P    0x07
+#define PBUS_FLIGHTSTICK_SHIFT_X    0x06
+#define PBUS_FLIGHTSTICK_SHIFT_LT   0x05
+#define PBUS_FLIGHTSTICK_SHIFT_RT   0x04
 
-#define PBUS_LG_SHIFT_TRIGGER 7
-#define PBUS_LG_SHIFT_SERVICE 6
-#define PBUS_LG_SHIFT_COINS   5
-#define PBUS_LG_SHIFT_START   4
-#define PBUS_LG_SHIFT_HOLSTER 3
-#define PBUS_LG_SHIFT_OPTION  3
+#define PBUS_MOUSE_SHIFT_LEFT       7
+#define PBUS_MOUSE_SHIFT_MIDDLE     6
+#define PBUS_MOUSE_SHIFT_RIGHT      5
+#define PBUS_MOUSE_SHIFT_SHIFT      4
+
+#define PBUS_LG_SHIFT_TRIGGER       7
+#define PBUS_LG_SHIFT_SERVICE       6
+#define PBUS_LG_SHIFT_COINS         5
+#define PBUS_LG_SHIFT_START         4
+#define PBUS_LG_SHIFT_HOLSTER       3
+#define PBUS_LG_SHIFT_OPTION        3
 
 #define PBUS_ORBATAK_SHIFT_COIN_P1  5
 #define PBUS_ORBATAK_SHIFT_COIN_P2  4
@@ -51,76 +65,94 @@ typedef struct pbus_s pbus_t;
 
 static pbus_t PBUS = {0,{0}};
 
-/*
-  It's possible that with multiple joypads should be packed into
-  32bits and intertwined in the format of:
-
-  CDAB GHEF
-
-  A = P1 MSB
-  B = P1 LSB
-  C = P2 MSB
-  D = P2 LSB
-  etc.
-*/
-static
 void
-pbus_add_joypad(const freedo_pbus_joypad_t *joypad_,
-                uint8_t                    *buf_)
+freedo_pbus_add_joypad(const freedo_pbus_joypad_t *jp_)
 {
-  buf_[3] = ((PBUS_JOYPAD_ID)                      |
-             (joypad_->d  << PBUS_JOYPAD_SHIFT_D)  |
-             (joypad_->u  << PBUS_JOYPAD_SHIFT_U)  |
-             (joypad_->r  << PBUS_JOYPAD_SHIFT_R)  |
-             (joypad_->l  << PBUS_JOYPAD_SHIFT_L)  |
-             (joypad_->a  << PBUS_JOYPAD_SHIFT_A));
-  buf_[2] = ((joypad_->b  << PBUS_JOYPAD_SHIFT_B)  |
-             (joypad_->c  << PBUS_JOYPAD_SHIFT_C)  |
-             (joypad_->p  << PBUS_JOYPAD_SHIFT_P)  |
-             (joypad_->x  << PBUS_JOYPAD_SHIFT_X)  |
-             (joypad_->rt << PBUS_JOYPAD_SHIFT_RT) |
-             (joypad_->lt << PBUS_JOYPAD_SHIFT_LT));
-  buf_[1] = 0xFF;
-  buf_[0] = 0xFF;
+  if((PBUS.idx + 2) >= PBUS_BUF_SIZE)
+    return;
+
+  PBUS.buf[PBUS.idx++] = ((PBUS_JOYPAD_ID)                  |
+                          (jp_->d  << PBUS_JOYPAD_SHIFT_D)  |
+                          (jp_->u  << PBUS_JOYPAD_SHIFT_U)  |
+                          (jp_->r  << PBUS_JOYPAD_SHIFT_R)  |
+                          (jp_->l  << PBUS_JOYPAD_SHIFT_L)  |
+                          (jp_->a  << PBUS_JOYPAD_SHIFT_A));
+  PBUS.buf[PBUS.idx++] = ((jp_->b  << PBUS_JOYPAD_SHIFT_B)  |
+                          (jp_->c  << PBUS_JOYPAD_SHIFT_C)  |
+                          (jp_->p  << PBUS_JOYPAD_SHIFT_P)  |
+                          (jp_->x  << PBUS_JOYPAD_SHIFT_X)  |
+                          (jp_->rt << PBUS_JOYPAD_SHIFT_RT) |
+                          (jp_->lt << PBUS_JOYPAD_SHIFT_LT));
 }
 
-static
 void
-pbus_add_flightstick(const freedo_pbus_flightstick_t *fs_,
-                     uint8_t                         *buf_)
+freedo_pbus_add_flightstick(const freedo_pbus_flightstick_t *fs_)
 {
-  /* TODO */
+  uint8_t x;
+  uint8_t y;
+  uint8_t z;
+
+  if((PBUS.idx + 9) >= PBUS_BUF_SIZE)
+    return;
+
+  x = ((fs_->h_pos + 32768) / (65536 / 256));
+  y = ((fs_->v_pos + 32768) / (65536 / 256));
+  z = ((fs_->z_pos + 32768) / (65536 / 256));
+
+  PBUS.buf[PBUS.idx++] = PBUS_FLIGHTSTICK_ID_0;
+  PBUS.buf[PBUS.idx++] = PBUS_FLIGHTSTICK_ID_1;
+  PBUS.buf[PBUS.idx++] = 0x08;
+  PBUS.buf[PBUS.idx++] = x;
+
+  PBUS.buf[PBUS.idx++] = (y >> 2);
+  PBUS.buf[PBUS.idx++] = (((y & 0x03) << 6) | ((z & 0xF0) >> 4));
+  PBUS.buf[PBUS.idx++] = (((z & 0x0F) << 4) | 0x02);
+  PBUS.buf[PBUS.idx++] = ((fs_->fire << PBUS_FLIGHTSTICK_SHIFT_FIRE) |
+                          (fs_->a    << PBUS_FLIGHTSTICK_SHIFT_A)    |
+                          (fs_->b    << PBUS_FLIGHTSTICK_SHIFT_B)    |
+                          (fs_->c    << PBUS_FLIGHTSTICK_SHIFT_C)    |
+                          (fs_->u    << PBUS_FLIGHTSTICK_SHIFT_U)    |
+                          (fs_->d    << PBUS_FLIGHTSTICK_SHIFT_D)    |
+                          (fs_->r    << PBUS_FLIGHTSTICK_SHIFT_R)    |
+                          (fs_->l    << PBUS_FLIGHTSTICK_SHIFT_L));
+
+  PBUS.buf[PBUS.idx++] = ((fs_->p    << PBUS_FLIGHTSTICK_SHIFT_P)    |
+                          (fs_->x    << PBUS_FLIGHTSTICK_SHIFT_X)    |
+                          (fs_->lt   << PBUS_FLIGHTSTICK_SHIFT_LT)   |
+                          (fs_->rt   << PBUS_FLIGHTSTICK_SHIFT_RT));
 }
 
-static
 void
-pbus_add_mouse(const freedo_pbus_mouse_t *mouse_,
-               uint8_t                   *buf_)
+freedo_pbus_add_mouse(const freedo_pbus_mouse_t *mouse_)
 {
-  buf_[3] = PBUS_MOUSE_ID;
-  buf_[2] = ((mouse_->left   << PBUS_MOUSE_SHIFT_LEFT)   |
-             (mouse_->middle << PBUS_MOUSE_SHIFT_MIDDLE) |
-             (mouse_->right  << PBUS_MOUSE_SHIFT_RIGHT)  |
-             (mouse_->shift  << PBUS_MOUSE_SHIFT_SHIFT) |
-             ((mouse_->y & 0x3C0) >> 6));
-  buf_[1] = (((mouse_->y & 0x03F) << 2) |
-             ((mouse_->x & 0x300) >> 8));
-  buf_[0] = (mouse_->x & 0xFF);
+  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
+    return;
+
+  PBUS.buf[PBUS.idx++] = PBUS_MOUSE_ID;
+  PBUS.buf[PBUS.idx++] = ((mouse_->left   << PBUS_MOUSE_SHIFT_LEFT)   |
+                          (mouse_->middle << PBUS_MOUSE_SHIFT_MIDDLE) |
+                          (mouse_->right  << PBUS_MOUSE_SHIFT_RIGHT)  |
+                          (mouse_->shift  << PBUS_MOUSE_SHIFT_SHIFT)  |
+                          ((mouse_->y & 0x3C0) >> 6));
+  PBUS.buf[PBUS.idx++] = (((mouse_->y & 0x03F) << 2) |
+                          ((mouse_->x & 0x300) >> 8));
+  PBUS.buf[PBUS.idx++] = (mouse_->x & 0xFF);
 }
 
 /*
   The algo below is derived from FreeDO's lightgun.cpp. It's not clear
   where all the constants come from or refer to.
 */
-static
 void
-pbus_add_lightgun(const freedo_pbus_lightgun_t *lg_,
-                  uint8_t                      *buf_)
+freedo_pbus_add_lightgun(const freedo_pbus_lightgun_t *lg_)
 {
   int32_t x;
   int32_t y;
   int32_t r;
   uint8_t trigger;
+
+  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
+    return;
 
   trigger = lg_->trigger;
   if(lg_->reload)
@@ -139,22 +171,23 @@ pbus_add_lightgun(const freedo_pbus_lightgun_t *lg_,
 
   r = (((y * 794.386) + x) / 5.0);
 
-  buf_[3] = PBUS_LIGHTGUN_ID;
-  buf_[2] = ((trigger      << PBUS_LG_SHIFT_TRIGGER) |
-             (lg_->option  << PBUS_LG_SHIFT_OPTION)  |
-             ((r & 0x10000) >> 16));
-  buf_[1] = ((r & 0xFF00) >> 8);
-  buf_[0] = (r & 0xFF);
+  PBUS.buf[PBUS.idx++] = PBUS_LIGHTGUN_ID;
+  PBUS.buf[PBUS.idx++] = ((trigger      << PBUS_LG_SHIFT_TRIGGER) |
+                          (lg_->option  << PBUS_LG_SHIFT_OPTION)  |
+                          ((r & 0x10000) >> 16));
+  PBUS.buf[PBUS.idx++] = ((r & 0xFF00) >> 8);
+  PBUS.buf[PBUS.idx++] = (r & 0xFF);
 }
 
-static
 void
-pbus_add_arcade_lightgun(const freedo_pbus_arcade_lightgun_t *lg_,
-                         uint8_t                             *buf_)
+freedo_pbus_add_arcade_lightgun(const freedo_pbus_arcade_lightgun_t *lg_)
 {
   int32_t x;
   int32_t y;
   int32_t r;
+
+  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
+    return;
 
   if(lg_->holster)
     {
@@ -171,89 +204,15 @@ pbus_add_arcade_lightgun(const freedo_pbus_arcade_lightgun_t *lg_,
 
   r = (((y * 794.386) + x) / 5.0);
 
-  buf_[3] = PBUS_LIGHTGUN_ID;
-  buf_[2] = ((lg_->trigger << PBUS_LG_SHIFT_TRIGGER) |
-             (lg_->service << PBUS_LG_SHIFT_SERVICE) |
-             (lg_->coins   << PBUS_LG_SHIFT_COINS)   |
-             (lg_->start   << PBUS_LG_SHIFT_START)   |
-             (lg_->holster << PBUS_LG_SHIFT_HOLSTER) |
-             ((r & 0x10000) >> 16));
-  buf_[1] = ((r & 0xFF00) >> 8);
-  buf_[0] = (r & 0xFF);
-}
-
-static
-void
-pbus_add_orbatak_trackball(const freedo_pbus_orbatak_trackball_t *tb_,
-                           uint8_t                               *buf_)
-{
-  buf_[3] = PBUS_ORBATAK_TRACKBALL_ID;
-  buf_[2] = ((tb_->y & 0x3C0) >> 6);
-  buf_[1] = (((tb_->y & 0x03F) << 2) |
-             ((tb_->x & 0x300) >> 8));
-  buf_[0] = (tb_->x & 0xFF);
-
-  buf_[7] = PBUS_ORBATAK_BUTTONS_ID;
-  buf_[6] = 0;
-  buf_[5] = ((tb_->coin_p1  << PBUS_ORBATAK_SHIFT_COIN_P1)  |
-             (tb_->coin_p2  << PBUS_ORBATAK_SHIFT_COIN_P2)  |
-             (tb_->start_p1 << PBUS_ORBATAK_SHIFT_START_P1) |
-             (tb_->start_p2 << PBUS_ORBATAK_SHIFT_START_P2) |
-             (tb_->service  << PBUS_ORBATAK_SHIFT_SERVICE));
-  buf_[4] = 0;
-}
-
-void
-freedo_pbus_add_joypad(const freedo_pbus_joypad_t *joypad_)
-{
-  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
-    return;
-
-  pbus_add_joypad(joypad_,&PBUS.buf[PBUS.idx]);
-  PBUS.idx += 4;
-}
-
-void
-freedo_pbus_add_mouse(const freedo_pbus_mouse_t *mouse_)
-{
-  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
-    return;
-
-  pbus_add_mouse(mouse_,&PBUS.buf[PBUS.idx]);
-  PBUS.idx += 4;
-}
-
-void
-freedo_pbus_add_lightgun(const freedo_pbus_lightgun_t *lg_)
-{
-  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
-    return;
-
-  pbus_add_lightgun(lg_,&PBUS.buf[PBUS.idx]);
-  PBUS.idx += 4;
-}
-
-void
-freedo_pbus_add_arcade_lightgun(const freedo_pbus_arcade_lightgun_t *lg_)
-{
-  if((PBUS.idx + 4) >= PBUS_BUF_SIZE)
-    return;
-
-  pbus_add_arcade_lightgun(lg_,&PBUS.buf[PBUS.idx]);
-  PBUS.idx += 4;
-}
-
-void
-freedo_pbus_add_flightstick(const freedo_pbus_flightstick_t *fs_)
-{
-  /* TODO */
-  return;
-
-  if((PBUS.idx + 8) >= PBUS_BUF_SIZE)
-    return;
-
-  pbus_add_flightstick(fs_,&PBUS.buf[PBUS.idx]);
-  PBUS.idx += 8;
+  PBUS.buf[PBUS.idx++] = PBUS_LIGHTGUN_ID;
+  PBUS.buf[PBUS.idx++] = ((lg_->trigger << PBUS_LG_SHIFT_TRIGGER) |
+                          (lg_->service << PBUS_LG_SHIFT_SERVICE) |
+                          (lg_->coins   << PBUS_LG_SHIFT_COINS)   |
+                          (lg_->start   << PBUS_LG_SHIFT_START)   |
+                          (lg_->holster << PBUS_LG_SHIFT_HOLSTER) |
+                          ((r & 0x10000) >> 16));
+  PBUS.buf[PBUS.idx++] = ((r & 0xFF00) >> 8);
+  PBUS.buf[PBUS.idx++] = (r & 0xFF);
 }
 
 void
@@ -262,8 +221,20 @@ freedo_pbus_add_orbatak_trackball(const freedo_pbus_orbatak_trackball_t *tb_)
   if((PBUS.idx + 8) >= PBUS_BUF_SIZE)
     return;
 
-  pbus_add_orbatak_trackball(tb_,&PBUS.buf[PBUS.idx]);
-  PBUS.idx += 8;
+  PBUS.buf[PBUS.idx++] = PBUS_ORBATAK_TRACKBALL_ID;
+  PBUS.buf[PBUS.idx++] = ((tb_->y & 0x3C0) >> 6);
+  PBUS.buf[PBUS.idx++] = (((tb_->y & 0x03F) << 2) |
+                          ((tb_->x & 0x300) >> 8));
+  PBUS.buf[PBUS.idx++] = (tb_->x & 0xFF);
+
+  PBUS.buf[PBUS.idx++] = PBUS_ORBATAK_BUTTONS_ID;
+  PBUS.buf[PBUS.idx++] = 0;
+  PBUS.buf[PBUS.idx++] = ((tb_->coin_p1  << PBUS_ORBATAK_SHIFT_COIN_P1)  |
+                          (tb_->coin_p2  << PBUS_ORBATAK_SHIFT_COIN_P2)  |
+                          (tb_->start_p1 << PBUS_ORBATAK_SHIFT_START_P1) |
+                          (tb_->start_p2 << PBUS_ORBATAK_SHIFT_START_P2) |
+                          (tb_->service  << PBUS_ORBATAK_SHIFT_SERVICE));
+  PBUS.buf[PBUS.idx++] = 0;
 }
 
 void*
@@ -276,6 +247,15 @@ uint32_t
 freedo_pbus_size(void)
 {
   return PBUS.idx;
+}
+
+void
+freedo_pbus_pad(void)
+{
+  int i;
+
+  for(i = 0; ((i < 8) && (PBUS.idx < PBUS_BUF_SIZE)); i++)
+    PBUS.buf[PBUS.idx++] = 0xFF;
 }
 
 void

--- a/libfreedo/freedo_pbus.h
+++ b/libfreedo/freedo_pbus.h
@@ -18,6 +18,26 @@ struct freedo_pbus_joypad_s
   uint8_t rt;
 };
 
+struct freedo_pbus_flightstick_s
+{
+  uint8_t fire;
+  uint8_t a;
+  uint8_t b;
+  uint8_t c;
+  uint8_t u;
+  uint8_t d;
+  uint8_t l;
+  uint8_t r;
+  uint8_t p;
+  uint8_t x;
+  uint8_t lt;
+  uint8_t rt;
+
+  int32_t h_pos;
+  int32_t v_pos;
+  int32_t z_pos;
+};
+
 struct freedo_pbus_mouse_s
 {
   uint8_t left;
@@ -51,35 +71,16 @@ struct freedo_pbus_arcade_lightgun_s
   int16_t y;
 };
 
-struct freedo_pbus_flightstick_s
-{
-  uint8_t fire;
-  uint8_t a;
-  uint8_t b;
-  uint8_t c;
-  uint8_t u;
-  uint8_t d;
-  uint8_t l;
-  uint8_t r;
-  uint8_t p;
-  uint8_t s;
-  uint8_t lt;
-  uint8_t rt;
-
-  int32_t h_pos;
-  int32_t v_pos;
-  int32_t z_pos;
-};
-
 struct freedo_pbus_orbatak_trackball_s
 {
-  int16_t x;
-  int16_t y;
   uint8_t start_p1;
   uint8_t start_p2;
   uint8_t coin_p1;
   uint8_t coin_p2;
   uint8_t service;
+
+  int16_t x;
+  int16_t y;
 };
 
 typedef struct freedo_pbus_joypad_s freedo_pbus_joypad_t;
@@ -91,6 +92,7 @@ typedef struct freedo_pbus_orbatak_trackball_s freedo_pbus_orbatak_trackball_t;
 
 void*    freedo_pbus_buf(void);
 uint32_t freedo_pbus_size(void);
+void     freedo_pbus_pad(void);
 void     freedo_pbus_reset(void);
 void     freedo_pbus_add_joypad(const freedo_pbus_joypad_t *joypad_);
 void     freedo_pbus_add_flightstick(const freedo_pbus_flightstick_t *fs_);

--- a/libfreedo/pbus.txt
+++ b/libfreedo/pbus.txt
@@ -66,9 +66,36 @@ MSB -> LSB
 1bit: X
 1bit: right trigger
 1bit: left trigger
-2bit: unused
-8bit: set (0xFF)
-8bit: set (0xFF)
+2bit: unused / 0
+
+
+### FLIGHTSTICK
+
+MSB -> LSB
+
+* 8bit: identifier 0 (0x01)
+* 8bit: identifier 1 (0x7B)
+* 8bit: length? (0x08)
+* 8bit: horizontal position
+* 2bit: 0
+* 8bit: vertical position
+* 2bit: 0
+* 8bit: depth position
+* 4bit: 0x02 (unsure what this means)
+* 1bit: trigger / fire
+* 1bit: A
+* 1bit: B
+* 1bit: C
+* 1bit: up
+* 1bit: down
+* 1bit: right
+* 1bit: left
+* 1bit: P
+* 1bit: X
+* 1bit: left trigger
+* 1bit: right trigger
+* 4bit: 0
+
 
 ### MOUSE
 
@@ -81,6 +108,7 @@ MSB -> LSB
 * 1bit: shift button
 * 10bit: X delta (signed)
 * 10bit: Y delta (signed)
+
 
 ### LIGHTGUN
 
@@ -139,6 +167,7 @@ x = ((((10 * counter) % NTSC_DEFAULT_YSCANTIME) * NTSC_WIDTH) /
 y = ((10 * counter) / NTSC_DEFAULT_YSCANTIME);
 ```
 
+
 ### ORBATAK TRACKBALL
 
 Orbatak uses two different devices. The trackballs are just mice as
@@ -156,6 +185,7 @@ MSB -> LSB
 1bit: start (p1)
 1bit: service
 8bit: 0x00
+
 
 ## Device Usage In Games
 
@@ -200,9 +230,7 @@ MSB -> LSB
 * Phoenix 3 (1995)
 * PO'ed (1995)
 * Return Fire (1995)
-* Road & Track Presents: The Need for Speed (1994)
 * Scramble Cobra (1995)
-* Shockwave: Operation Jumpgate (1995)
 * Shockwave 2: Beyond The Gate (1995)
 * Space Ace (1995)
 * Star Fighter (1996)

--- a/lr_input.c
+++ b/lr_input.c
@@ -114,7 +114,7 @@ lr_input_poll_flightstick(const int port_)
   fs.l    = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_LEFT);
   fs.r    = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_RIGHT);
   fs.p    = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_START);
-  fs.s    = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_SELECT);
+  fs.x    = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_SELECT);
   fs.lt   = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_L);
   fs.rt   = poll_joypad(port_,RETRO_DEVICE_ID_JOYPAD_R);
 


### PR DESCRIPTION
This isn't perfect. While the wire data is confirmed accurate by using a logic analyzer something about the emulation leads to inconsistent behavior. Bladeforce (retail) fails to properly recognize the flightstick but the beta release works (Y is backwards though).

Games tested and working:

* Bladeforce beta v2.3
* Star Wars - Rebel Assult
* Killing Time v3.10
* Super Wing Commander
* Star Fighter (it sortof works after fooling with input for a while)
