### PR TITLE
add ability to run DSP on separate thread

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -20,7 +20,8 @@ SOURCES_C := \
         $(CORE_DIR)/retro_cdimage.c \
         $(CORE_DIR)/lr_input.c \
         $(CORE_DIR)/lr_input_crosshair.c \
-        $(CORE_DIR)/lr_input_descs.c
+        $(CORE_DIR)/lr_input_descs.c \
+        $(CORE_DIR)/lr_dsp.c                                     
 
 SOURCES_C += \
 	$(4DO_DIR)/freedo_3do.c \
@@ -67,6 +68,10 @@ FLAGS += \
 	-DHAVE_STDINT_H \
 	-DHAVE_STDLIB_H \
 	-DHAVE_SYS_PARAM_H
+
+ifeq ($(THREADED_DSP), 1)
+FLAGS += -DTHREADED_DSP
+endif
 
 ifeq ($(HAVE_CHD), 1)
 FLAGS += \

--- a/libfreedo/freedo_3do.c
+++ b/libfreedo/freedo_3do.c
@@ -136,7 +136,7 @@ freedo_3do_internal_frame(vdlp_frame_t *frame_,
 
   freedo_quarz_push_cycles(cycles_);
   if(freedo_quarz_queue_dsp())
-    io_interface(EXT_PUSH_SAMPLE,(void*)(uintptr_t)freedo_dsp_loop());
+    io_interface(EXT_DSP_TRIGGER,NULL);
 
   if(freedo_quarz_queue_timer())
     freedo_clio_timer_execute();

--- a/libfreedo/freedo_core.h
+++ b/libfreedo/freedo_core.h
@@ -24,55 +24,16 @@ Felix Lazarev
 #ifndef __3DO_SYSTEM_HEADER_DEFINITION
 #define __3DO_SYSTEM_HEADER_DEFINITION
 
+#include "extern_c.h"
+
 #include <stdint.h>
 #include <boolean.h>
 
-#include "extern_c.h"
-
-#pragma pack(push,1)
-
-struct BitmapCrop
-{
-	int left;
-	int top;
-	int bottom;
-	int right;
-};
-
-struct GetFrameBitmapParams
-{
-	struct VDLFrame* sourceFrame;
-	void* destinationBitmap;
-	int destinationBitmapWidthPixels;
-	struct BitmapCrop* bitmapCrop;
-	int copyWidthPixels;
-	int copyHeightPixels;
-	bool addBlackBorder;
-	bool copyPointlessAlphaByte;
-	bool allowCrop;
-	int resultingWidth;
-	int resultingHeight;
-};
-
-#pragma pack(pop)
-
-#define EXT_READ_ROMS           1
-#define EXT_SWAPFRAME           5       //frame swap (in mutlithreaded) or frame draw(single treaded)
-#define EXT_PUSH_SAMPLE         6       //sends sample to the buffer
-#define EXT_KPRINT              9
-#define EXT_DEBUG_PRINT         10
-#define EXT_FRAMETRIGGER_MT     12      //multitasking
-#define EXT_READ2048            14      //for XBUS Plugin
-#define EXT_GET_DISC_SIZE       15
-#define EXT_ON_SECTOR           16
-#define EXT_ARM_SYNC            17
+#define EXT_SWAPFRAME     1  /* frame should be read */
+#define EXT_DSP_TRIGGER   2  /* DSP should be triggered
+                                (freedo_dsp_loop) */
 
 typedef void* (*freedo_ext_interface_t)(int, void*);
-
-#define FDP_FREEDOCORE_VERSION   0
-#define FDP_DO_FRAME_MT          4      //multitasking
-
-#define BIOS_ANVIL (0x40)
 
 EXTERN_C_BEGIN
 

--- a/libretro-common/rthreads/ctr_pthread.h
+++ b/libretro-common/rthreads/ctr_pthread.h
@@ -1,0 +1,196 @@
+/* Copyright  (C) 2010-2018 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (gx_pthread.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _CTR_PTHREAD_WRAP_CTR_
+#define _CTR_PTHREAD_WRAP_CTR_
+
+#include <3ds/thread.h>
+#include <3ds/synchronization.h>
+#include <3ds/svc.h>
+#include <time.h>
+#include <errno.h>
+#include <retro_inline.h>
+
+#define STACKSIZE (4 * 1024)
+
+typedef Thread     pthread_t;
+typedef LightLock  pthread_mutex_t;
+typedef void*      pthread_mutexattr_t;
+typedef int        pthread_attr_t;
+typedef LightEvent pthread_cond_t;
+typedef int        pthread_condattr_t;
+
+/* libctru threads return void but pthreads return void pointer */
+static bool mutex_inited = false;
+static LightLock safe_double_thread_launch;
+static void *(*start_routine_jump)(void*);
+
+static void ctr_thread_launcher(void* data)
+{
+	void *(*start_routine_jump_safe)(void*) = start_routine_jump;
+	LightLock_Unlock(&safe_double_thread_launch);
+	start_routine_jump_safe(data);
+}
+
+static INLINE int pthread_create(pthread_t *thread,
+      const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg)
+{
+   s32 prio = 0;
+   Thread new_ctr_thread;
+      
+   if (!mutex_inited)
+   {
+	   LightLock_Init(&safe_double_thread_launch);
+	   mutex_inited = true;
+   }
+   
+   /*Must wait if attempting to launch 2 threads at once to prevent corruption of function pointer*/
+   while (LightLock_TryLock(&safe_double_thread_launch) != 0);
+   
+   svcGetThreadPriority(&prio, CUR_THREAD_HANDLE);
+   
+   start_routine_jump = start_routine;
+   new_ctr_thread     = threadCreate(ctr_thread_launcher, arg, STACKSIZE, prio - 1, -1/*No affinity, use any CPU*/, false);
+   
+   if (!new_ctr_thread)
+   {
+	   LightLock_Unlock(&safe_double_thread_launch);
+	   return EAGAIN;
+   }
+   
+   *thread = new_ctr_thread;
+   return 0;
+}
+
+static INLINE pthread_t pthread_self(void)
+{
+   return threadGetCurrent();
+}
+
+static INLINE int pthread_mutex_init(pthread_mutex_t *mutex,
+      const pthread_mutexattr_t *attr)
+{
+   LightLock_Init(mutex);
+   return 0;
+}
+
+static INLINE int pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+   /*Nothing to destroy*/
+   return 0;
+}
+
+static INLINE int pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+   return LightLock_TryLock(mutex);
+}
+
+static INLINE int pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+   LightLock_Unlock(mutex);
+   return 0;
+}
+
+static INLINE void pthread_exit(void *retval)
+{
+   /*Yes the pointer to int cast is not ideal*/
+   /*threadExit((int)retval);*/
+   (void)retval;
+}
+
+static INLINE int pthread_detach(pthread_t thread)
+{
+   /* FIXME: pthread_detach equivalent missing? */
+   (void)thread;
+   return 0;
+}
+
+static INLINE int pthread_join(pthread_t thread, void **retval)
+{
+   /*retval is ignored*/
+   return threadJoin(thread, U64_MAX);
+}
+
+static INLINE int pthread_mutex_trylock(pthread_mutex_t *mutex)
+{
+   return LightLock_TryLock(mutex);
+}
+
+static INLINE int pthread_cond_wait(pthread_cond_t *cond,
+      pthread_mutex_t *mutex)
+{
+   LightEvent_Wait(cond);
+   return 0;
+}
+
+static INLINE int pthread_cond_timedwait(pthread_cond_t *cond,
+      pthread_mutex_t *mutex, const struct timespec *abstime)
+{
+   while (true)
+   {
+       struct timespec now = {0};
+	    /* Missing clock_gettime*/
+       struct timeval tm;
+      
+       gettimeofday(&tm, NULL);
+       now.tv_sec = tm.tv_sec;
+       now.tv_nsec = tm.tv_usec * 1000;
+       if (LightEvent_TryWait(cond) != 0 || now.tv_sec > abstime->tv_sec || (now.tv_sec == abstime->tv_sec && now.tv_nsec > abstime->tv_nsec))
+		   break;
+   }
+	
+   return 0;
+}
+
+static INLINE int pthread_cond_init(pthread_cond_t *cond,
+      const pthread_condattr_t *attr)
+{
+   LightEvent_Init(cond, RESET_ONESHOT);
+   return 0;
+}
+
+static INLINE int pthread_cond_signal(pthread_cond_t *cond)
+{
+   LightEvent_Signal(cond);
+   return 0;
+}
+
+static INLINE int pthread_cond_broadcast(pthread_cond_t *cond)
+{
+   LightEvent_Signal(cond);
+   return 0;
+}
+
+static INLINE int pthread_cond_destroy(pthread_cond_t *cond)
+{
+   /*nothing to destroy*/
+   return 0;
+}
+
+static INLINE int pthread_equal(pthread_t t1, pthread_t t2)
+{
+	if (threadGetHandle(t1) == threadGetHandle(t2))
+		return 1;
+	return 0;
+}
+
+#endif

--- a/libretro-common/rthreads/gx_pthread.h
+++ b/libretro-common/rthreads/gx_pthread.h
@@ -1,0 +1,185 @@
+/* Copyright  (C) 2010-2018 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (gx_pthread.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _GX_PTHREAD_WRAP_GX_
+#define _GX_PTHREAD_WRAP_GX_
+
+#include <ogcsys.h>
+#include <gccore.h>
+#include <ogc/cond.h>
+#include <retro_inline.h>
+
+#ifndef OSThread
+#define OSThread lwp_t
+#endif
+
+#ifndef OSCond
+#define OSCond lwpq_t
+#endif
+
+#ifndef OSThreadQueue
+#define OSThreadQueue lwpq_t
+#endif
+
+#ifndef OSInitMutex
+#define OSInitMutex(mutex) LWP_MutexInit(mutex, 0)
+#endif
+
+#ifndef OSLockMutex
+#define OSLockMutex(mutex) LWP_MutexLock(mutex)
+#endif
+
+#ifndef OSUnlockMutex
+#define OSUnlockMutex(mutex) LWP_MutexUnlock(mutex)
+#endif
+
+#ifndef OSTryLockMutex
+#define OSTryLockMutex(mutex) LWP_MutexTryLock(mutex)
+#endif
+
+#ifndef OSInitCond
+#define OSInitCond(cond) LWP_CondInit(cond)
+#endif
+
+#ifndef OSWaitCond
+#define OSWaitCond(cond, mutex) LWP_CondWait(cond, mutex)
+#endif
+
+#ifndef OSInitThreadQueue
+#define OSInitThreadQueue(queue) LWP_InitQueue(queue)
+#endif
+
+#ifndef OSSleepThread
+#define OSSleepThread(queue) LWP_ThreadSleep(queue)
+#endif
+
+#ifndef OSJoinThread
+#define OSJoinThread(thread, val) LWP_JoinThread(thread, val)
+#endif
+
+#ifndef OSCreateThread
+#define OSCreateThread(thread, func, intarg, ptrarg, stackbase, stacksize, priority, attrs) LWP_CreateThread(thread, func, ptrarg, stackbase, stacksize, priority)
+#endif
+
+#define STACKSIZE (8 * 1024)
+
+typedef OSThread pthread_t;
+typedef mutex_t pthread_mutex_t;
+typedef void* pthread_mutexattr_t;
+typedef int pthread_attr_t;
+typedef OSCond pthread_cond_t;
+typedef OSCond pthread_condattr_t;
+
+static INLINE int pthread_create(pthread_t *thread,
+      const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg)
+{
+   *thread = 0;
+   return OSCreateThread(thread, start_routine, 0 /* unused */, arg,
+         0, STACKSIZE, 64, 0 /* unused */);
+}
+
+static INLINE pthread_t pthread_self(void)
+{
+   /* zero 20-mar-2016: untested */
+   return LWP_GetSelf();
+}
+
+static INLINE int pthread_mutex_init(pthread_mutex_t *mutex,
+      const pthread_mutexattr_t *attr)
+{
+   return OSInitMutex(mutex);
+}
+
+static INLINE int pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+   return LWP_MutexDestroy(*mutex);
+}
+
+static INLINE int pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+   return OSLockMutex(*mutex);
+}
+
+static INLINE int pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+   return OSUnlockMutex(*mutex);
+}
+
+static INLINE void pthread_exit(void *retval)
+{
+   /* FIXME: No LWP equivalent for this? */
+   (void)retval;
+}
+
+static INLINE int pthread_detach(pthread_t thread)
+{
+   /* FIXME: pthread_detach equivalent missing? */
+   (void)thread;
+   return 0;
+}
+
+static INLINE int pthread_join(pthread_t thread, void **retval)
+{
+   return OSJoinThread(thread, retval);
+}
+
+static INLINE int pthread_mutex_trylock(pthread_mutex_t *mutex)
+{
+   return OSTryLockMutex(*mutex);
+}
+
+static INLINE int pthread_cond_wait(pthread_cond_t *cond,
+      pthread_mutex_t *mutex)
+{
+   return OSWaitCond(*cond, *mutex);
+}
+
+static INLINE int pthread_cond_timedwait(pthread_cond_t *cond,
+      pthread_mutex_t *mutex, const struct timespec *abstime)
+{
+   return LWP_CondTimedWait(*cond, *mutex, abstime);
+}
+
+static INLINE int pthread_cond_init(pthread_cond_t *cond,
+      const pthread_condattr_t *attr)
+{
+   return OSInitCond(cond);
+}
+
+static INLINE int pthread_cond_signal(pthread_cond_t *cond)
+{
+   return LWP_CondSignal(*cond);
+}
+
+static INLINE int pthread_cond_broadcast(pthread_cond_t *cond)
+{
+   return LWP_CondBroadcast(*cond);
+}
+
+static INLINE int pthread_cond_destroy(pthread_cond_t *cond)
+{
+   return LWP_CondDestroy(*cond);
+}
+
+extern int pthread_equal(pthread_t t1, pthread_t t2);
+
+#endif

--- a/libretro-common/rthreads/psp_pthread.h
+++ b/libretro-common/rthreads/psp_pthread.h
@@ -1,0 +1,309 @@
+/* Copyright  (C) 2010-2017 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (psp_pthread.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* FIXME: unfinished on PSP, mutexes and condition variables basically a stub. */
+#ifndef _PSP_PTHREAD_WRAP__
+#define _PSP_PTHREAD_WRAP__
+
+#ifdef VITA
+#include <psp2/kernel/threadmgr.h>
+#include <sys/time.h>
+#else
+#include <pspkernel.h>
+#include <pspthreadman.h>
+#include <pspthreadman_kernel.h>
+#endif
+#include <stdio.h>
+#include <retro_inline.h>
+
+#define STACKSIZE (8 * 1024)
+
+typedef SceUID pthread_t;
+typedef SceUID pthread_mutex_t;
+typedef void* pthread_mutexattr_t;
+typedef int pthread_attr_t;
+
+typedef struct
+{
+	SceUID mutex;
+	SceUID sema;
+	int waiting;
+} pthread_cond_t;
+
+typedef SceUID pthread_condattr_t;
+
+/* Use pointer values to create unique names for threads/mutexes */
+char name_buffer[256];
+
+typedef void* (*sthreadEntry)(void *argp);
+
+typedef struct
+{
+   void* arg;
+   sthreadEntry start_routine;
+} sthread_args_struct;
+
+
+static int psp_thread_wrap(SceSize args, void *argp)
+{
+   sthread_args_struct* sthread_args = (sthread_args_struct*)argp;
+
+   return (int)sthread_args->start_routine(sthread_args->arg);
+}
+
+static INLINE int pthread_create(pthread_t *thread,
+      const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg)
+{
+   snprintf(name_buffer, sizeof(name_buffer), "0x%08X", (unsigned int) thread);
+
+#ifdef VITA
+   *thread = sceKernelCreateThread(name_buffer, psp_thread_wrap,
+         0x10000100, 0x10000, 0, 0, NULL);
+#else
+   *thread = sceKernelCreateThread(name_buffer,
+         psp_thread_wrap, 0x20, STACKSIZE, 0, NULL);
+#endif
+
+   sthread_args_struct sthread_args;
+   sthread_args.arg = arg;
+   sthread_args.start_routine = start_routine;
+
+   return sceKernelStartThread(*thread, sizeof(sthread_args), &sthread_args);
+}
+
+static INLINE int pthread_mutex_init(pthread_mutex_t *mutex,
+      const pthread_mutexattr_t *attr)
+{
+   snprintf(name_buffer, sizeof(name_buffer), "0x%08X", (unsigned int) mutex);
+
+#ifdef VITA
+   *mutex = sceKernelCreateMutex(name_buffer, 0, 0, 0);
+	 if(*mutex<0)
+	 		return *mutex;
+	 return 0;
+#else
+   return *mutex = sceKernelCreateSema(name_buffer, 0, 1, 1, NULL);
+#endif
+}
+
+static INLINE int pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+#ifdef VITA
+   return sceKernelDeleteMutex(*mutex);
+#else
+   return sceKernelDeleteSema(*mutex);
+#endif
+}
+
+static INLINE int pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+#ifdef VITA
+	 int ret = sceKernelLockMutex(*mutex, 1, 0);
+	 return ret;
+
+#else
+   /* FIXME: stub */
+   return 1;
+#endif
+}
+
+static INLINE int pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+#ifdef VITA
+	int ret = sceKernelUnlockMutex(*mutex, 1);
+	return ret;
+#else
+   /* FIXME: stub */
+   return 1;
+#endif
+}
+
+
+static INLINE int pthread_join(pthread_t thread, void **retval)
+{
+#ifdef VITA
+   int res = sceKernelWaitThreadEnd(thread, 0, 0);
+   if (res < 0)
+      return res;
+   return sceKernelDeleteThread(thread);
+#else
+   SceUInt timeout = (SceUInt)-1;
+   sceKernelWaitThreadEnd(thread, &timeout);
+   exit_status = sceKernelGetThreadExitStatus(thread);
+   sceKernelDeleteThread(thread);
+   return exit_status;
+#endif
+}
+
+static INLINE int pthread_mutex_trylock(pthread_mutex_t *mutex)
+{
+#ifdef VITA
+   return sceKernelTryLockMutex(*mutex, 1 /* not sure about this last param */);
+#else
+   /* FIXME: stub */
+   return 1;
+#endif
+}
+
+static INLINE int pthread_cond_wait(pthread_cond_t *cond,
+      pthread_mutex_t *mutex)
+{
+#ifdef VITA
+   int ret = pthread_mutex_lock(&cond->mutex);
+   if (ret < 0)
+      return ret;
+   ++cond->waiting;
+   pthread_mutex_unlock(mutex);
+   pthread_mutex_unlock(&cond->mutex);
+
+   ret = sceKernelWaitSema(cond->sema, 1, 0);
+   if (ret < 0)
+      sceClibPrintf("Premature wakeup: %08X", ret);
+   pthread_mutex_lock(mutex);
+   return ret;
+#else
+   /* FIXME: stub */
+   sceKernelDelayThread(10000);
+   return 1;
+#endif
+}
+
+static INLINE int pthread_cond_timedwait(pthread_cond_t *cond,
+      pthread_mutex_t *mutex, const struct timespec *abstime)
+{
+#ifdef VITA
+   int ret = pthread_mutex_lock(&cond->mutex);
+   if (ret < 0)
+      return ret;
+   ++cond->waiting;
+   pthread_mutex_unlock(mutex);
+   pthread_mutex_unlock(&cond->mutex);
+
+   SceUInt timeout = 0;
+
+   timeout  = abstime->tv_sec;
+   timeout += abstime->tv_nsec / 1.0e6;
+
+   ret = sceKernelWaitSema(cond->sema, 1, &timeout);
+   if (ret < 0)
+      sceClibPrintf("Premature wakeup: %08X", ret);
+   pthread_mutex_lock(mutex);
+   return ret;
+
+#else
+   /* FIXME: stub */
+   return 1;
+#endif
+}
+
+static INLINE int pthread_cond_init(pthread_cond_t *cond,
+      const pthread_condattr_t *attr)
+{
+#ifdef VITA
+
+   pthread_mutex_init(&cond->mutex,NULL);
+
+   if(cond->mutex<0)
+      return cond->mutex;
+
+   snprintf(name_buffer, sizeof(name_buffer), "0x%08X", (unsigned int) cond);
+   cond->sema = sceKernelCreateSema(name_buffer, 0, 0, 1, 0);
+
+   if(cond->sema < 0)
+   {
+      pthread_mutex_destroy(&cond->mutex);
+      return cond->sema;
+   }
+
+   cond->waiting = 0;
+
+   return 0;
+
+
+#else
+   /* FIXME: stub */
+   return 1;
+#endif
+}
+
+static INLINE int pthread_cond_signal(pthread_cond_t *cond)
+{
+#ifdef VITA
+	pthread_mutex_lock(&cond->mutex);
+	if (cond->waiting)
+   {
+		--cond->waiting;
+		sceKernelSignalSema(cond->sema, 1);
+	}
+	pthread_mutex_unlock(&cond->mutex);
+	return 0;
+#else
+   /* FIXME: stub */
+   return 1;
+#endif
+}
+
+static INLINE int pthread_cond_broadcast(pthread_cond_t *cond)
+{
+   /* FIXME: stub */
+   return 1;
+}
+
+static INLINE int pthread_cond_destroy(pthread_cond_t *cond)
+{
+#ifdef VITA
+   int ret = sceKernelDeleteSema(cond->sema);
+   if(ret < 0)
+    return ret;
+
+   return sceKernelDeleteMutex(cond->mutex);
+#else
+  /* FIXME: stub */
+  return 1;
+#endif
+}
+
+
+static INLINE int pthread_detach(pthread_t thread)
+{
+   return 0;
+}
+
+static INLINE void pthread_exit(void *retval)
+{
+#ifdef VITA
+   sceKernelExitDeleteThread(sceKernelGetThreadId());
+#endif
+}
+
+static INLINE pthread_t pthread_self(void)
+{
+   /* zero 20-mar-2016: untested */
+   return sceKernelGetThreadId();
+}
+
+static INLINE int pthread_equal(pthread_t t1, pthread_t t2)
+{
+	 return t1 == t2;
+}
+
+#endif //_PSP_PTHREAD_WRAP__

--- a/libretro-common/rthreads/rthreads.c
+++ b/libretro-common/rthreads/rthreads.c
@@ -1,0 +1,868 @@
+/* Copyright  (C) 2010-2018 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (rthreads.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifdef __unix__
+#ifndef __sun__
+#define _POSIX_C_SOURCE 199309
+#endif
+#endif
+
+#include <stdlib.h>
+
+#include <boolean.h>
+#include <rthreads/rthreads.h>
+
+/* with RETRO_WIN32_USE_PTHREADS, pthreads can be used even on win32. Maybe only supported in MSVC>=2005  */
+
+#if defined(_WIN32) && !defined(RETRO_WIN32_USE_PTHREADS)
+#define USE_WIN32_THREADS
+#ifdef _XBOX
+#include <xtl.h>
+#else
+#define WIN32_LEAN_AND_MEAN
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0500 /*_WIN32_WINNT_WIN2K */
+#endif
+#include <windows.h>
+#include <mmsystem.h>
+#endif
+#elif defined(GEKKO)
+#include "gx_pthread.h"
+#elif defined(_3DS)
+#include "ctr_pthread.h"
+#elif defined(__CELLOS_LV2__)
+#include <pthread.h>
+#include <sys/sys_time.h>
+#else
+#include <pthread.h>
+#include <time.h>
+#endif
+
+#if defined(VITA) || defined(BSD)
+#include <sys/time.h>
+#endif
+
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
+struct thread_data
+{
+   void (*func)(void*);
+   void *userdata;
+};
+
+struct sthread
+{
+#ifdef USE_WIN32_THREADS
+   HANDLE thread;
+   DWORD id;
+#else
+   pthread_t id;
+#endif
+};
+
+struct slock
+{
+#ifdef USE_WIN32_THREADS
+   CRITICAL_SECTION lock;
+#else
+   pthread_mutex_t lock;
+#endif
+};
+
+#ifdef USE_WIN32_THREADS
+/* The syntax we'll use is mind-bending unless we use a struct. Plus, we might want to store more info later */
+/* This will be used as a linked list immplementing a queue of waiting threads */
+struct QueueEntry
+{
+   struct QueueEntry *next;
+};
+#endif
+
+struct scond
+{
+#ifdef USE_WIN32_THREADS
+   /* With this implementation of scond, we don't have any way of waking
+    * (or even identifying) specific threads
+    * But we need to wake them in the order indicated by the queue.
+    * This potato token will get get passed around every waiter.
+    * The bearer can test whether he's next, and hold onto the potato if he is.
+    * When he's done he can then put it back into play to progress
+    * the queue further */
+   HANDLE hot_potato;
+
+   /* The primary signalled event. Hot potatoes are passed until this is set. */
+   HANDLE event;
+
+   /* the head of the queue; NULL if queue is empty */
+   struct QueueEntry *head;
+
+   /* equivalent to the queue length */
+   int waiters;
+
+   /* how many waiters in the queue have been conceptually wakened by signals
+    * (even if we haven't managed to actually wake them yet) */
+   int wakens;
+
+   /* used to control access to this scond, in case the user fails */
+   CRITICAL_SECTION cs;
+
+#else
+   pthread_cond_t cond;
+#endif
+};
+
+#ifdef USE_WIN32_THREADS
+static DWORD CALLBACK thread_wrap(void *data_)
+#else
+static void *thread_wrap(void *data_)
+#endif
+{
+   struct thread_data *data = (struct thread_data*)data_;
+   if (!data)
+	   return 0;
+   data->func(data->userdata);
+   free(data);
+   return 0;
+}
+
+/**
+ * sthread_create:
+ * @start_routine           : thread entry callback function
+ * @userdata                : pointer to userdata that will be made
+ *                            available in thread entry callback function
+ *
+ * Create a new thread.
+ *
+ * Returns: pointer to new thread if successful, otherwise NULL.
+ */
+sthread_t *sthread_create(void (*thread_func)(void*), void *userdata)
+{
+   bool thread_created      = false;
+   struct thread_data *data = NULL;
+   sthread_t *thread        = (sthread_t*)calloc(1, sizeof(*thread));
+
+   if (!thread)
+      return NULL;
+
+   data                     = (struct thread_data*)calloc(1, sizeof(*data));
+   if (!data)
+      goto error;
+
+   data->func = thread_func;
+   data->userdata = userdata;
+
+#ifdef USE_WIN32_THREADS
+   thread->thread = CreateThread(NULL, 0, thread_wrap, data, 0, &thread->id);
+   thread_created = !!thread->thread;
+#else
+#if defined(VITA)
+   pthread_attr_t thread_attr;
+   pthread_attr_init(&thread_attr);
+   pthread_attr_setstacksize(&thread_attr , 0x10000 );
+   thread_created = pthread_create(&thread->id, &thread_attr, thread_wrap, data) == 0;
+#else
+   thread_created = pthread_create(&thread->id, NULL, thread_wrap, data) == 0;
+#endif
+#endif
+
+   if (!thread_created)
+      goto error;
+
+   return thread;
+
+error:
+   if (data)
+      free(data);
+   free(thread);
+   return NULL;
+}
+
+/**
+ * sthread_detach:
+ * @thread                  : pointer to thread object
+ *
+ * Detach a thread. When a detached thread terminates, its
+ * resources are automatically released back to the system
+ * without the need for another thread to join with the
+ * terminated thread.
+ *
+ * Returns: 0 on success, otherwise it returns a non-zero error number.
+ */
+int sthread_detach(sthread_t *thread)
+{
+#ifdef USE_WIN32_THREADS
+   CloseHandle(thread->thread);
+   free(thread);
+   return 0;
+#else
+   return pthread_detach(thread->id);
+#endif
+}
+
+/**
+ * sthread_join:
+ * @thread                  : pointer to thread object
+ *
+ * Join with a terminated thread. Waits for the thread specified by
+ * @thread to terminate. If that thread has already terminated, then
+ * it will return immediately. The thread specified by @thread must
+ * be joinable.
+ *
+ * Returns: 0 on success, otherwise it returns a non-zero error number.
+ */
+void sthread_join(sthread_t *thread)
+{
+   if (!thread)
+      return;
+#ifdef USE_WIN32_THREADS
+   WaitForSingleObject(thread->thread, INFINITE);
+   CloseHandle(thread->thread);
+#else
+   pthread_join(thread->id, NULL);
+#endif
+   free(thread);
+}
+
+/**
+ * sthread_isself:
+ * @thread                  : pointer to thread object
+ *
+ * Returns: true (1) if calling thread is the specified thread
+ */
+bool sthread_isself(sthread_t *thread)
+{
+  /* This thread can't possibly be a null thread */
+  if (!thread)
+     return false;
+
+#ifdef USE_WIN32_THREADS
+   return GetCurrentThreadId() == thread->id;
+#else
+   return pthread_equal(pthread_self(),thread->id);
+#endif
+}
+
+/**
+ * slock_new:
+ *
+ * Create and initialize a new mutex. Must be manually
+ * freed.
+ *
+ * Returns: pointer to a new mutex if successful, otherwise NULL.
+ **/
+slock_t *slock_new(void)
+{
+   bool mutex_created = false;
+   slock_t      *lock = (slock_t*)calloc(1, sizeof(*lock));
+   if (!lock)
+      return NULL;
+
+#ifdef USE_WIN32_THREADS
+   InitializeCriticalSection(&lock->lock);
+   mutex_created = true;
+#else
+   mutex_created = (pthread_mutex_init(&lock->lock, NULL) == 0);
+#endif
+
+   if (!mutex_created)
+      goto error;
+
+   return lock;
+
+error:
+   free(lock);
+   return NULL;
+}
+
+/**
+ * slock_free:
+ * @lock                    : pointer to mutex object
+ *
+ * Frees a mutex.
+ **/
+void slock_free(slock_t *lock)
+{
+   if (!lock)
+      return;
+
+#ifdef USE_WIN32_THREADS
+   DeleteCriticalSection(&lock->lock);
+#else
+   pthread_mutex_destroy(&lock->lock);
+#endif
+   free(lock);
+}
+
+/**
+ * slock_lock:
+ * @lock                    : pointer to mutex object
+ *
+ * Locks a mutex. If a mutex is already locked by
+ * another thread, the calling thread shall block until
+ * the mutex becomes available.
+**/
+void slock_lock(slock_t *lock)
+{
+   if (!lock)
+      return;
+#ifdef USE_WIN32_THREADS
+   EnterCriticalSection(&lock->lock);
+#else
+   pthread_mutex_lock(&lock->lock);
+#endif
+}
+
+/**
+ * slock_unlock:
+ * @lock                    : pointer to mutex object
+ *
+ * Unlocks a mutex.
+ **/
+void slock_unlock(slock_t *lock)
+{
+   if (!lock)
+      return;
+#ifdef USE_WIN32_THREADS
+   LeaveCriticalSection(&lock->lock);
+#else
+   pthread_mutex_unlock(&lock->lock);
+#endif
+}
+
+/**
+ * scond_new:
+ *
+ * Creates and initializes a condition variable. Must
+ * be manually freed.
+ *
+ * Returns: pointer to new condition variable on success,
+ * otherwise NULL.
+ **/
+scond_t *scond_new(void)
+{
+   scond_t      *cond = (scond_t*)calloc(1, sizeof(*cond));
+
+   if (!cond)
+      return NULL;
+
+#ifdef USE_WIN32_THREADS
+
+   /* This is very complex because recreating condition variable semantics
+    * with Win32 parts is not easy.
+    *
+    * The main problem is that a condition variable can't be used to
+    * "pre-wake" a thread (it will get wakened only after it's waited).
+    *
+    * Whereas a win32 event can pre-wake a thread (the event will be set
+    * in advance, so a 'waiter' won't even have to wait on it).
+    *
+    * Keep in mind a condition variable can apparently pre-wake a thread,
+    * insofar as spurious wakeups are always possible,
+    * but nobody will be expecting this and it does not need to be simulated.
+    *
+    * Moreover, we won't be doing this, because it counts as a spurious wakeup
+    * -- someone else with a genuine claim must get wakened, in any case.
+    *
+    * Therefore we choose to wake only one of the correct waiting threads.
+    * So at the very least, we need to do something clever. But there's
+    * bigger problems.
+    * We don't even have a straightforward way in win32 to satisfy
+    * pthread_cond_wait's atomicity requirement. The bulk of this
+    * algorithm is solving that.
+    *
+    * Note: We might could simplify this using vista+ condition variables,
+    * but we wanted an XP compatible solution. */
+   cond->event = CreateEvent(NULL, FALSE, FALSE, NULL);
+   if (!cond->event) goto error;
+   cond->hot_potato = CreateEvent(NULL, FALSE, FALSE, NULL);
+   if (!cond->hot_potato)
+   {
+      CloseHandle(cond->event);
+      goto error;
+   }
+
+   InitializeCriticalSection(&cond->cs);
+   cond->waiters = cond->wakens = 0;
+   cond->head = NULL;
+
+#else
+   if (pthread_cond_init(&cond->cond, NULL) != 0)
+      goto error;
+#endif
+
+   return cond;
+
+error:
+   free(cond);
+   return NULL;
+}
+
+/**
+ * scond_free:
+ * @cond                    : pointer to condition variable object
+ *
+ * Frees a condition variable.
+**/
+void scond_free(scond_t *cond)
+{
+   if (!cond)
+      return;
+
+#ifdef USE_WIN32_THREADS
+   CloseHandle(cond->event);
+   CloseHandle(cond->hot_potato);
+   DeleteCriticalSection(&cond->cs);
+#else
+   pthread_cond_destroy(&cond->cond);
+#endif
+   free(cond);
+}
+
+#ifdef USE_WIN32_THREADS
+static bool _scond_wait_win32(scond_t *cond, slock_t *lock, DWORD dwMilliseconds)
+{
+   struct QueueEntry myentry;
+   struct QueueEntry **ptr;
+
+#if _WIN32_WINNT >= 0x0500 || defined(_XBOX)
+   static LARGE_INTEGER performanceCounterFrequency;
+   LARGE_INTEGER tsBegin;
+   static bool first_init  = true;
+#else
+   static bool beginPeriod = false;
+   DWORD tsBegin;
+#endif
+
+   DWORD waitResult;
+   DWORD dwFinalTimeout = dwMilliseconds; /* Careful! in case we begin in the head,
+                                             we don't do the hot potato stuff,
+                                             so this timeout needs presetting. */
+
+   /* Reminder: `lock` is held before this is called. */
+   /* however, someone else may have called scond_signal without the lock. soo... */
+   EnterCriticalSection(&cond->cs);
+
+   /* since this library is meant for realtime game software
+    * I have no problem setting this to 1 and forgetting about it. */
+#if _WIN32_WINNT >= 0x0500 || defined(_XBOX)
+   if (first_init)
+   {
+      performanceCounterFrequency.QuadPart = 0;
+      first_init = false;
+   }
+
+   if (performanceCounterFrequency.QuadPart == 0)
+   {
+      QueryPerformanceFrequency(&performanceCounterFrequency);
+   }
+#else
+   if (!beginPeriod)
+   {
+      beginPeriod = true;
+      timeBeginPeriod(1);
+   }
+#endif
+
+   /* Now we can take a good timestamp for use in faking the timeout ourselves. */
+   /* But don't bother unless we need to (to save a little time) */
+   if (dwMilliseconds != INFINITE)
+#if _WIN32_WINNT >= 0x0500 || defined(_XBOX)
+      QueryPerformanceCounter(&tsBegin);
+#else
+      tsBegin = timeGetTime();
+#endif
+
+   /* add ourselves to a queue of waiting threads */
+   ptr = &cond->head;
+
+   /* walk to the end of the linked list */
+   while (*ptr)
+      ptr = &((*ptr)->next);
+
+   *ptr = &myentry;
+   myentry.next = NULL;
+
+   cond->waiters++;
+
+   /* now the conceptual lock release and condition block are supposed to be atomic.
+    * we can't do that in Windows, but we can simulate the effects by using
+    * the queue, by the following analysis:
+    * What happens if they aren't atomic?
+    *
+    * 1. a signaller can rush in and signal, expecting a waiter to get it;
+    * but the waiter wouldn't, because he isn't blocked yet.
+    * Solution: Win32 events make this easy. The event will sit there enabled
+    *
+    * 2. a signaller can rush in and signal, and then turn right around and wait.
+    * Solution: the signaller will get queued behind the waiter, who's
+    * enqueued before he releases the mutex. */
+
+   /* It's my turn if I'm the head of the queue.
+    * Check to see if it's my turn. */
+   while (cond->head != &myentry)
+   {
+      /* It isn't my turn: */
+      DWORD timeout = INFINITE;
+
+      /* As long as someone is even going to be able to wake up
+       * when they receive the potato, keep it going round. */
+      if (cond->wakens > 0)
+         SetEvent(cond->hot_potato);
+
+      /* Assess the remaining timeout time */
+      if (dwMilliseconds != INFINITE)
+      {
+#if _WIN32_WINNT >= 0x0500 || defined(_XBOX)
+         LARGE_INTEGER now;
+         LONGLONG elapsed;
+
+         QueryPerformanceCounter(&now);
+         elapsed  = now.QuadPart - tsBegin.QuadPart;
+         elapsed *= 1000;
+         elapsed /= performanceCounterFrequency.QuadPart;
+#else
+         DWORD now     = timeGetTime();
+         DWORD elapsed = now - tsBegin;
+#endif
+
+         /* Try one last time with a zero timeout (keeps the code simpler) */
+         if (elapsed > dwMilliseconds)
+            elapsed = dwMilliseconds;
+
+         timeout = dwMilliseconds - elapsed;
+      }
+
+      /* Let someone else go */
+      LeaveCriticalSection(&lock->lock);
+      LeaveCriticalSection(&cond->cs);
+
+      /* Wait a while to catch the hot potato..
+       * someone else should get a chance to go */
+      /* After all, it isn't my turn (and it must be someone else's) */
+      Sleep(0);
+      waitResult = WaitForSingleObject(cond->hot_potato, timeout);
+
+      /* I should come out of here with the main lock taken */
+      EnterCriticalSection(&lock->lock);
+      EnterCriticalSection(&cond->cs);
+
+      if (waitResult == WAIT_TIMEOUT)
+      {
+         /* Out of time! Now, let's think about this. I do have the potato now--
+          * maybe it's my turn, and I have the event?
+          * If that's the case, I could proceed right now without aborting
+          * due to timeout.
+          *
+          * However.. I DID wait a real long time. The caller was willing
+          * to wait that long.
+          *
+          * I choose to give him one last chance with a zero timeout
+          * in the next step
+          */
+         if (cond->head == &myentry)
+         {
+            dwFinalTimeout = 0;
+            break;
+         }
+         else
+         {
+            /* It's not our turn and we're out of time. Give up.
+             * Remove ourself from the queue and bail. */
+            struct QueueEntry* curr = cond->head;
+
+            while (curr->next != &myentry)
+               curr = curr->next;
+            curr->next = myentry.next;
+            cond->waiters--;
+            LeaveCriticalSection(&cond->cs);
+            return false;
+         }
+      }
+
+   }
+
+   /* It's my turn now -- and I hold the potato */
+
+   /* I still have the main lock, in any case */
+   /* I need to release it so that someone can set the event */
+   LeaveCriticalSection(&lock->lock);
+   LeaveCriticalSection(&cond->cs);
+
+   /* Wait for someone to actually signal this condition */
+   /* We're the only waiter waiting on the event right now -- everyone else
+    * is waiting on something different */
+   waitResult = WaitForSingleObject(cond->event, dwFinalTimeout);
+
+   /* Take the main lock so we can do work. Nobody else waits on this lock
+    * for very long, so even though it's GO TIME we won't have to wait long */
+   EnterCriticalSection(&lock->lock);
+   EnterCriticalSection(&cond->cs);
+
+   /* Remove ourselves from the queue */
+   cond->head = myentry.next;
+   cond->waiters--;
+
+   if (waitResult == WAIT_TIMEOUT)
+   {
+      /* Oops! ran out of time in the final wait. Just bail. */
+      LeaveCriticalSection(&cond->cs);
+      return false;
+   }
+
+   /* If any other wakenings are pending, go ahead and set it up  */
+   /* There may actually be no waiters. That's OK. The first waiter will come in,
+    * find it's his turn, and immediately get the signaled event */
+   cond->wakens--;
+   if (cond->wakens > 0)
+   {
+      SetEvent(cond->event);
+
+      /* Progress the queue: Put the hot potato back into play. It'll be
+       * tossed around until next in line gets it */
+      SetEvent(cond->hot_potato);
+   }
+
+   LeaveCriticalSection(&cond->cs);
+   return true;
+}
+#endif
+
+/**
+ * scond_wait:
+ * @cond                    : pointer to condition variable object
+ * @lock                    : pointer to mutex object
+ *
+ * Block on a condition variable (i.e. wait on a condition).
+ **/
+void scond_wait(scond_t *cond, slock_t *lock)
+{
+#ifdef USE_WIN32_THREADS
+   _scond_wait_win32(cond, lock, INFINITE);
+#else
+   pthread_cond_wait(&cond->cond, &lock->lock);
+#endif
+}
+
+/**
+ * scond_broadcast:
+ * @cond                    : pointer to condition variable object
+ *
+ * Broadcast a condition. Unblocks all threads currently blocked
+ * on the specified condition variable @cond.
+ **/
+int scond_broadcast(scond_t *cond)
+{
+#ifdef USE_WIN32_THREADS
+   /* remember: we currently have mutex */
+   if (cond->waiters == 0)
+      return 0;
+
+   /* awaken everything which is currently queued up */
+   if (cond->wakens == 0)
+      SetEvent(cond->event);
+   cond->wakens = cond->waiters;
+
+   /* Since there is now at least one pending waken, the potato must be in play */
+   SetEvent(cond->hot_potato);
+
+   return 0;
+#else
+   return pthread_cond_broadcast(&cond->cond);
+#endif
+}
+
+/**
+ * scond_signal:
+ * @cond                    : pointer to condition variable object
+ *
+ * Signal a condition. Unblocks at least one of the threads currently blocked
+ * on the specified condition variable @cond.
+ **/
+void scond_signal(scond_t *cond)
+{
+#ifdef USE_WIN32_THREADS
+
+   /* Unfortunately, pthread_cond_signal does not require that the
+    * lock be held in advance */
+   /* To avoid stomping on the condvar from other threads, we need
+    * to control access to it with this */
+   EnterCriticalSection(&cond->cs);
+
+   /* remember: we currently have mutex */
+   if (cond->waiters == 0)
+   {
+      LeaveCriticalSection(&cond->cs);
+      return;
+   }
+
+   /* wake up the next thing in the queue */
+   if (cond->wakens == 0)
+      SetEvent(cond->event);
+
+   cond->wakens++;
+
+   /* The data structure is done being modified.. I think we can leave the CS now.
+    * This would prevent some other thread from receiving the hot potato and then
+    * immediately stalling for the critical section.
+    * But remember, we were trying to replicate a semantic where this entire
+    * scond_signal call was controlled (by the user) by a lock.
+    * So in case there's trouble with this, we can move it after SetEvent() */
+   LeaveCriticalSection(&cond->cs);
+
+   /* Since there is now at least one pending waken, the potato must be in play */
+   SetEvent(cond->hot_potato);
+
+#else
+   pthread_cond_signal(&cond->cond);
+#endif
+}
+
+/**
+ * scond_wait_timeout:
+ * @cond                    : pointer to condition variable object
+ * @lock                    : pointer to mutex object
+ * @timeout_us              : timeout (in microseconds)
+ *
+ * Try to block on a condition variable (i.e. wait on a condition) until
+ * @timeout_us elapses.
+ *
+ * Returns: false (0) if timeout elapses before condition variable is
+ * signaled or broadcast, otherwise true (1).
+ **/
+bool scond_wait_timeout(scond_t *cond, slock_t *lock, int64_t timeout_us)
+{
+#ifdef USE_WIN32_THREADS
+   /* How to convert a microsecond (us) timeout to millisecond (ms)?
+    *
+    * Someone asking for a 0 timeout clearly wants immediate timeout.
+    * Someone asking for a 1 timeout clearly wants an actual timeout
+    * of the minimum length */
+
+   /* Someone asking for 1000 or 1001 timeout shouldn't
+    * accidentally get 2ms. */
+   DWORD dwMilliseconds = timeout_us/1000;
+
+   /* The implementation of a 0 timeout here with pthreads is sketchy.
+    * It isn't clear what happens if pthread_cond_timedwait is called with NOW.
+    * Moreover, it is possible that this thread gets pre-empted after the
+    * clock_gettime but before the pthread_cond_timedwait.
+    * In order to help smoke out problems caused by this strange usage,
+    * let's treat a 0 timeout as always timing out.
+    */
+   if (timeout_us == 0)
+      return false;
+   else if (timeout_us < 1000)
+      dwMilliseconds = 1;
+
+   return _scond_wait_win32(cond,lock,dwMilliseconds);
+#else
+   int ret;
+   int64_t seconds, remainder;
+   struct timespec now = {0};
+
+#ifdef __MACH__
+   /* OSX doesn't have clock_gettime. */
+   clock_serv_t cclock;
+   mach_timespec_t mts;
+
+   host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+   clock_get_time(cclock, &mts);
+   mach_port_deallocate(mach_task_self(), cclock);
+   now.tv_sec = mts.tv_sec;
+   now.tv_nsec = mts.tv_nsec;
+#elif defined(__CELLOS_LV2__)
+   sys_time_sec_t s;
+   sys_time_nsec_t n;
+
+   sys_time_get_current_time(&s, &n);
+   now.tv_sec  = s;
+   now.tv_nsec = n;
+#elif defined(__mips__) || defined(VITA) || defined(_3DS)
+   struct timeval tm;
+
+   gettimeofday(&tm, NULL);
+   now.tv_sec = tm.tv_sec;
+   now.tv_nsec = tm.tv_usec * 1000;
+#elif defined(RETRO_WIN32_USE_PTHREADS)
+   _ftime64_s(&now);
+#elif !defined(GEKKO)
+   /* timeout on libogc is duration, not end time. */
+   clock_gettime(CLOCK_REALTIME, &now);
+#endif
+
+   seconds      = timeout_us / INT64_C(1000000);
+   remainder    = timeout_us % INT64_C(1000000);
+
+   now.tv_sec  += seconds;
+   now.tv_nsec += remainder * INT64_C(1000);
+
+   if (now.tv_nsec > 1000000000)
+   {
+      now.tv_nsec -= 1000000000;
+      now.tv_sec += 1;
+   }
+
+   ret = pthread_cond_timedwait(&cond->cond, &lock->lock, &now);
+   return (ret == 0);
+#endif
+}
+
+#ifdef HAVE_THREAD_STORAGE
+bool sthread_tls_create(sthread_tls_t *tls)
+{
+#ifdef USE_WIN32_THREADS
+   return (*tls = TlsAlloc()) != TLS_OUT_OF_INDEXES;
+#else
+   return pthread_key_create((pthread_key_t*)tls, NULL) == 0;
+#endif
+}
+
+bool sthread_tls_delete(sthread_tls_t *tls)
+{
+#ifdef USE_WIN32_THREADS
+   return TlsFree(*tls) != 0;
+#else
+   return pthread_key_delete(*tls) == 0;
+#endif
+}
+
+void *sthread_tls_get(sthread_tls_t *tls)
+{
+#ifdef USE_WIN32_THREADS
+   return TlsGetValue(*tls);
+#else
+   return pthread_getspecific(*tls);
+#endif
+}
+
+bool sthread_tls_set(sthread_tls_t *tls, const void *data)
+{
+#ifdef USE_WIN32_THREADS
+   return TlsSetValue(*tls, (void*)data) != 0;
+#else
+   return pthread_setspecific(*tls, data) == 0;
+#endif
+}
+#endif

--- a/libretro-common/rthreads/xenon_sdl_threads.c
+++ b/libretro-common/rthreads/xenon_sdl_threads.c
@@ -1,0 +1,59 @@
+/* Copyright  (C) 2010-2018 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (xenon_sdl_threads.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* libSDLxenon doesn't implement this yet :[. Implement it very stupidly for now. ;) */
+
+#include "SDL_thread.h"
+#include "SDL_mutex.h"
+#include <stdlib.h>
+#include <boolean.h>
+
+SDL_cond *SDL_CreateCond(void)
+{
+   bool *sleeping = calloc(1, sizeof(*sleeping));
+   return (SDL_cond*)sleeping;
+}
+
+void SDL_DestroyCond(SDL_cond *sleeping)
+{
+   free(sleeping);
+}
+
+int SDL_CondWait(SDL_cond *cond, SDL_mutex *lock)
+{
+   (void)lock;
+   volatile bool *sleeping = (volatile bool*)cond;
+
+   SDL_mutexV(lock);
+   *sleeping = true;
+   while (*sleeping); /* Yeah, we all love busyloops don't we? ._. */
+   SDL_mutexP(lock);
+
+   return 0;
+}
+
+int SDL_CondSignal(SDL_cond *cond)
+{
+   *(volatile bool*)cond = false;
+   return 0;
+}
+

--- a/lr_dsp.c
+++ b/lr_dsp.c
@@ -1,0 +1,5 @@
+#if THREADED_DSP
+#include "lr_dsp_threaded.ic"
+#else
+#include "lr_dsp_regular.ic"
+#endif

--- a/lr_dsp.h
+++ b/lr_dsp.h
@@ -1,0 +1,12 @@
+#ifndef LIBRETRO_4DO_LR_DSP_H_INCLUDED
+#define LIBRETRO_4DO_LR_DSP_H_INCLUDED
+
+#include <boolean.h>
+
+void lr_dsp_init(const bool threaded_);
+void lr_dsp_destroy(void);
+
+void lr_dsp_upload(void);
+void lr_dsp_process(void);
+
+#endif /* LIBRETRO_4DO_LR_DSP_H_INCLUDED */

--- a/lr_dsp_regular.ic
+++ b/lr_dsp_regular.ic
@@ -1,0 +1,42 @@
+#include "libfreedo/freedo_dsp.h"
+
+#include "retro_callbacks.h"
+
+#include <boolean.h>
+#include <stdint.h>
+
+/* MACROS */
+#define DSP_BUF_SIZE ((44100 / 60) * 4)
+
+/* GLOBAL VARIABLES */
+static uint32_t g_dsp_buf_idx = 0;
+static int32_t  g_dsp_buf[DSP_BUF_SIZE];
+
+/* PUBLIC FUNCTIONS */
+
+void
+lr_dsp_process(void)
+{
+  g_dsp_buf[g_dsp_buf_idx++] = freedo_dsp_loop();
+  if(g_dsp_buf_idx > DSP_BUF_SIZE)
+    g_dsp_buf_idx = 0;
+}
+
+void
+lr_dsp_upload(void)
+{
+  retro_audio_sample_batch_cb((int16_t*)g_dsp_buf,g_dsp_buf_idx);
+  g_dsp_buf_idx = 0;
+}
+
+void
+lr_dsp_destroy(void)
+{
+
+}
+
+void
+lr_dsp_init(const bool threaded_)
+{
+
+}

--- a/lr_dsp_threaded.ic
+++ b/lr_dsp_threaded.ic
@@ -1,0 +1,141 @@
+#include "libfreedo/freedo_dsp.h"
+
+#include "retro_callbacks.h"
+
+#include <boolean.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <stdint.h>
+
+/* FORWARD DECLARATIONS */
+static void dsp_process(void);
+static void dsp_upload_unlocked(void);
+
+/* MACROS */
+#define DSP_BUF_SIZE ((44100 / 60) * 4)
+
+/* GLOBAL VARIABLES */
+static bool g_dsp_threaded = false;
+
+static uint32_t g_dsp_buf_idx = 0;
+static int32_t  g_dsp_buf[DSP_BUF_SIZE];
+
+static sem_t g_dsp_sem;
+static pthread_t g_dsp_thread;
+static pthread_mutex_t g_dsp_buf_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static void (*g_dsp_upload)(void)  = dsp_upload_unlocked;
+static void (*g_dsp_process)(void) = dsp_process;
+
+
+/* PRIVATE FUNCTIONS */
+
+static
+void *
+dsp_thread_loop(void *handle_)
+{
+  int32_t sample;
+
+  for(;;)
+    {
+      sem_wait(&g_dsp_sem);
+
+      sample = freedo_dsp_loop();
+
+      pthread_mutex_lock(&g_dsp_buf_mutex);
+      g_dsp_buf[g_dsp_buf_idx++] = sample;
+      if(g_dsp_buf_idx > DSP_BUF_SIZE)
+        g_dsp_buf_idx = 0;
+      pthread_mutex_unlock(&g_dsp_buf_mutex);
+    }
+
+  return NULL;
+}
+
+static
+void
+dsp_upload_unlocked(void)
+{
+  retro_audio_sample_batch_cb((int16_t*)g_dsp_buf,g_dsp_buf_idx);
+  g_dsp_buf_idx = 0;
+}
+
+static
+void
+dsp_upload_locked(void)
+{
+  pthread_mutex_lock(&g_dsp_buf_mutex);
+
+  dsp_upload_unlocked();
+
+  pthread_mutex_unlock(&g_dsp_buf_mutex);
+}
+
+static
+void
+dsp_process(void)
+{
+  g_dsp_buf[g_dsp_buf_idx++] = freedo_dsp_loop();
+  if(g_dsp_buf_idx > DSP_BUF_SIZE)
+    g_dsp_buf_idx = 0;
+}
+
+static
+void
+dsp_process_threaded(void)
+{
+  sem_post(&g_dsp_sem);
+}
+
+
+/* PUBLIC FUNCTIONS */
+
+void
+lr_dsp_process(void)
+{
+  (*g_dsp_process)();
+}
+
+void
+lr_dsp_upload(void)
+{
+  (*g_dsp_upload)();
+}
+
+void
+lr_dsp_destroy(void)
+{
+  void *rv;
+
+  if(g_dsp_threaded)
+    {
+      pthread_cancel(g_dsp_thread);
+      pthread_join(g_dsp_thread,&rv);
+      sem_destroy(&g_dsp_sem);
+    }
+}
+
+void
+lr_dsp_init(const bool threaded_)
+{
+  if(g_dsp_threaded == threaded_)
+    return;
+
+  lr_dsp_destroy();
+
+  g_dsp_buf_idx = 0;
+
+  g_dsp_threaded = threaded_;
+  if(g_dsp_threaded)
+    {
+      sem_init(&g_dsp_sem,0,0);
+      pthread_create(&g_dsp_thread,NULL,dsp_thread_loop,NULL);
+      g_dsp_upload  = dsp_upload_locked;
+      g_dsp_process = dsp_process_threaded;
+    }
+  else
+    {
+      g_dsp_upload  = dsp_upload_unlocked;
+      g_dsp_process = dsp_process;
+    }
+}

--- a/retro_callbacks.c
+++ b/retro_callbacks.c
@@ -1,11 +1,18 @@
 #include <libretro.h>
 
+retro_audio_sample_t       retro_audio_sample_cb       = NULL;
 retro_audio_sample_batch_t retro_audio_sample_batch_cb = NULL;
 retro_environment_t        retro_environment_cb        = NULL;
 retro_input_poll_t         retro_input_poll_cb         = NULL;
 retro_input_state_t        retro_input_state_cb        = NULL;
 retro_log_printf_t         retro_log_printf_cb         = NULL;
 retro_video_refresh_t      retro_video_refresh_cb      = NULL;
+
+void
+retro_set_audio_sample_cb(retro_audio_sample_t cb_)
+{
+  retro_audio_sample_cb = cb_;
+}
 
 void
 retro_set_audio_sample_batch_cb(retro_audio_sample_batch_t cb_)

--- a/retro_callbacks.h
+++ b/retro_callbacks.h
@@ -3,6 +3,7 @@
 
 #include <libretro.h>
 
+extern retro_audio_sample_t       retro_audio_sample_cb;
 extern retro_audio_sample_batch_t retro_audio_sample_batch_cb;
 extern retro_environment_t        retro_environment_cb;
 extern retro_input_poll_t         retro_input_poll_cb;
@@ -10,6 +11,7 @@ extern retro_input_state_t        retro_input_state_cb;
 extern retro_log_printf_t         retro_log_printf_cb;
 extern retro_video_refresh_t      retro_video_refresh_cb;
 
+void retro_set_audio_sample_cb(retro_audio_sample_t cb_);
 void retro_set_audio_sample_batch_cb(retro_audio_sample_batch_t cb_);
 void retro_set_environment_cb(retro_environment_t cb_);
 void retro_set_input_poll_cb(retro_input_poll_t cb_);


### PR DESCRIPTION
Code was refactored to keep the handling of audio outside libfreedo to give the client control in order to make threading easier. Can be toggled live. Currently uses posix threads and only triggered to build on unix platforms. Moving to rthreads or enabling building on other platforms to come later.

Performance increases are seen with dsp threading enabled upwards of 20%.