### PR TITLE
cue/img file support

### DIFF
--- a/retro_cdimage.c
+++ b/retro_cdimage.c
@@ -96,6 +96,8 @@ retro_cdimage_open_cue(const char *path_,
     rv = retro_cdimage_open_iso(cue_file->cd_image,cdimage_);
   else if(!strcasecmp(ext,"bin"))
     rv = retro_cdimage_open_bin(cue_file->cd_image,cdimage_);
+  else if(!strcasecmp(ext,"img"))
+    rv = retro_cdimage_open_bin(cue_file->cd_image,cdimage_);
   else
     rv = -1;
 


### PR DESCRIPTION
Some ripping softwares such as CDManipulator create cue/img files instead of cue/bin files.
They only differ in extentions.