### PR TITLE
Fix options when using frontends without core options API v1 support

### DIFF
--- a/libretro_core_options.c
+++ b/libretro_core_options.c
@@ -456,8 +456,13 @@ void libretro_set_core_options(void)
                   break;
             }
 
-            /* Build values string */
-            if (num_values > 1)
+            /* Build values string
+             * > Note: 4DO is unusual in that we have to
+             *   support core options with only one value
+             *   (the number of '4do_bios' and '4do_font'
+             *   options depends upon the number of files
+             *   present in the user's system directory...) */
+            if (num_values > 0)
             {
                size_t j;
 


### PR DESCRIPTION
At present, core options are not displayed correctly when using frontends that require the old v0 core options API *if* the user has no bios files in their system directory. This PR fixes the issue.